### PR TITLE
Remove sha256 h2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crypt.fyi/cli",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "bin": {
     "cfyi": "./dist/index.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crypt.fyi/core",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -20,7 +20,6 @@ export type ReadVaultParams = z.infer<typeof readVaultParamsSchema>;
 
 export const readVaultQuerySchema = z.object({
   h: z.string().describe('sha512 hash of the encryption key + optional password'),
-  h2: z.string().describe('sha256 hash of the encryption key + optional password').optional(),
 });
 export type ReadVaultQuery = z.infer<typeof readVaultQuerySchema>;
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -147,8 +147,7 @@ export class Client {
 
   async read(id: string, key: string, password?: string) {
     const h = sha512(key + (password ?? ''));
-    const h2 = sha256(key + (password ?? ''));
-    const res = await fetch(`${this.apiUrl}/vault/${id}?h=${h}&h2=${h2}`, {
+    const res = await fetch(`${this.apiUrl}/vault/${id}?h=${h}`, {
       headers: this.getHeaders(),
     });
     if (!res.ok) {

--- a/packages/core/src/vault.ts
+++ b/packages/core/src/vault.ts
@@ -34,7 +34,6 @@ export interface Vault {
   get(
     id: string,
     h: string,
-    h2: string,
     ip: string,
   ): Promise<Pick<VaultValue, 'c' | 'b' | 'ttl' | 'cd'> | undefined>;
   del(id: string, dt: string): Promise<boolean>;

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@crypt.fyi/extension",
   "license": "Apache-2.0",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@crypt.fyi/server",
   "license": "Apache-2.0",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "dist/index.js",
   "description": "crypt.fyi server",
   "scripts": {

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -314,41 +314,4 @@ describe('app', () => {
     });
     expect(getResponse.statusCode).toBe(404);
   });
-
-  it('should allow either sha512 or sha256 hash during migration period', async () => {
-    const createResponse = await testContext.client.request({
-      method: 'POST',
-      path: '/vault',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        c: 'foobar',
-        b: false,
-        h: 'abc123',
-      }),
-    });
-
-    expect(createResponse.statusCode).toBe(201);
-
-    const { id } = (await createResponse.body.json()) as Record<string, unknown>;
-
-    const getResponse = await testContext.client.request({
-      method: 'GET',
-      path: `/vault/${id}?h=abc123&h2=xyz321`,
-    });
-    expect(getResponse.statusCode).toBe(200);
-
-    const getResponse2 = await testContext.client.request({
-      method: 'GET',
-      path: `/vault/${id}?h=xyz321&h2=abc123`,
-    });
-    expect(getResponse2.statusCode).toBe(200);
-
-    const getResponse3 = await testContext.client.request({
-      method: 'GET',
-      path: `/vault/${id}?h=xyz321&h2=abc1234`,
-    });
-    expect(getResponse3.statusCode).toBe(400);
-  });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -273,7 +273,7 @@ export const initApp = async (config: Config, deps: AppDeps) => {
     },
     async handler(req, res) {
       try {
-        const result = await vault.get(req.params.vaultId, req.query.h, req.query.h2 ?? '', req.ip);
+        const result = await vault.get(req.params.vaultId, req.query.h, req.ip);
         if (!result) {
           return res.status(404).send();
         }

--- a/packages/server/src/vault/redis.ts
+++ b/packages/server/src/vault/redis.ts
@@ -71,7 +71,7 @@ export const createRedisVault = (
 
       return { id, dt };
     },
-    async get(id, h, h2, ip) {
+    async get(id, h, ip) {
       const key = getKey(id);
 
       // TODO: try to not pull the full redis entry into memory until the ip address is confirmed to be allowed
@@ -105,7 +105,7 @@ export const createRedisVault = (
   end
 
   local data = cjson.decode(value)
-  if data.h ~= ARGV[1] and data.h ~= ARGV[2] then
+  if data.h ~= ARGV[1] then
     return cjson.encode({ status = "invalid_hash" })
   end
 
@@ -147,7 +147,6 @@ export const createRedisVault = (
         1,
         key,
         h,
-        h2,
       )) as string | null;
       if (!outcome) {
         return undefined;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@crypt.fyi/web",
   "private": true,
   "license": "Apache-2.0",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This is expected to break retrieval for anyone using cli or browser extension that uses the sha256 hashing. The web has already been cutover and no more sha256 hashes exist.