### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/osbytes/crypt.fyi/security/code-scanning/13](https://github.com/osbytes/crypt.fyi/security/code-scanning/13)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow does not appear to require any write permissions, we will set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` used in the workflow has only read access to the repository contents, reducing the risk of unintended modifications.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
