### PR TITLE
fix: clear read count when burn after read is checked

### DIFF
--- a/packages/web/src/pages/Create.tsx
+++ b/packages/web/src/pages/Create.tsx
@@ -780,7 +780,12 @@ export function CreatePage() {
                             <Checkbox
                               {...rest}
                               checked={value}
-                              onCheckedChange={onChange}
+                              onCheckedChange={(checked) => {
+                                onChange(checked);
+                                if (checked) {
+                                  form.setValue('rc', undefined);
+                                }
+                              }}
                               disabled={createMutation.isPending || rest.disabled}
                             />
                           </FormControl>


### PR DESCRIPTION
## Summary

- When "burn after read" is checked, the read count value is cleared to `undefined`
- Mirrors the existing inverse behavior at line 864 where setting a read count unchecks burn after read
- These two options are mutually exclusive; now both directions auto-clear the other

Closes #103

## Test plan

- [ ] Check "burn after read" after setting a read count value: read count should be cleared
- [ ] Set a read count value: burn after read should still auto-uncheck (existing behavior unchanged)
- [ ] Uncheck "burn after read": read count field should remain empty (no regression)