### PR TITLE
Add Playwright CSP smoke and security dependency overrides

### DIFF
--- a/.changeset/playwright-csp-and-security.md
+++ b/.changeset/playwright-csp-and-security.md
@@ -1,0 +1,5 @@
+---
+'@crypt.fyi/web': patch
+---
+
+Add Playwright create/read CSP smoke coverage, include the missing sonner `style-src` hash in nginx CSP, and apply pnpm audit overrides for transitive CVEs. Core unit tests use fast KDF params so CI stays quick.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,13 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @crypt.fyi/web exec playwright install chromium --with-deps
+
+      - name: E2E smoke (create + read)
+        run: pnpm test:e2e
+        env:
+          CI: true
+          VITE_API_URL: http://localhost:4321
+          REDIS_URL: redis://127.0.0.1:6379

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist
 redis-data
 dist.zip
 extension.zip
+**/test-results/
+**/playwright-report/
+**/blob-report/

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,6 @@ coverage
 *.md
 *.gen.ts
 pnpm-lock.yaml
+**/test-results/
+**/playwright-report/
+**/blob-report/

--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ Publishable packages: `@crypt.fyi/core` and `@crypt.fyi/cli` (npm), plus the Chr
 
 ### Content Security Policy
 
-- The toast notification library (sonner) requires specific style-src hashes in the CSP configuration
-- These hashes are defined in `nginx/nginx.conf`
-- Updates to sonner may require updating these hashes
+- Production CSP (including `style-src` hashes for sonner/Radix inline styles) lives in `nginx/nginx.conf`
+- `vite preview` applies that same policy via `packages/web/csp.ts` so local/CI match production
+- `pnpm test:e2e` runs a Playwright create→read smoke under that CSP. It fails on `style-src` / `connect-src` violations; other console warnings/errors and non-style CSP noise (e.g. `script-src` eval fallback notes) are reported as non-blocking annotations
+- When the smoke fails on style-src, add the reported hash to `nginx/nginx.conf` (do not weaken to `'unsafe-inline'`)
 - Reference: [sonner#449](https://github.com/emilkowalski/sonner/issues/449)
 
 ### Development Environment

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -22,13 +22,9 @@ server {
 
     location / {
         try_files $uri $uri/ $uri.html /index.html;
-        # Known Issue: sonner toast library requires explicit style-src hashes in CSP
-        # These hashes are for specific inline styles used by sonner
-        # Warning: Updates to sonner may require updating these hashes
-        # See: https://github.com/emilkowalski/sonner/issues/449
-        # Radix UI also requires explicit style-src hashes in CSP
-        # See: https://github.com/radix-ui/primitives/discussions/3130
-        add_header Content-Security-Policy "default-src 'self'; connect-src 'self' $api_url; style-src 'self' 'unsafe-hashes' 'sha256-7lAG9nNPimWNBky6j9qnn0jfFzu5wK96KOj/UzoG0hg=' 'sha256-Q9MUdYBtYzn5frLpoNRLdFYW76cJ4ok2SmIKzTFq57Q=' 'sha256-ciREV5hbiDCRpVWah2irtNbfqy9H2pRaA/FB5FiJ/28=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' 'sha256-441zG27rExd4/il+NvIqyL8zFx5XmyNQtE381kSkUJk=' 'sha256-nzTgYzXYDNe6BAHiiI7NNlfK8n/auuOAhh2t92YvuXo=' 'sha256-kAApudxpTi9mfjlC9lC8ZaS9xFHU9/NLLbB173MU7SU='; img-src 'self' blob: https://www.osbytes.io;";
+        # sonner + Radix need style-src hashes (sonner#449, radix#3130).
+        # Drift is caught by the Playwright create/read smoke (securitypolicyviolation).
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; connect-src 'self' $api_url; style-src 'self' 'unsafe-hashes' 'sha256-CIxDM5jnsGiKqXs2v7NKCY5MzdR9gu6TtiMJrDw29AY=' 'sha256-7lAG9nNPimWNBky6j9qnn0jfFzu5wK96KOj/UzoG0hg=' 'sha256-Q9MUdYBtYzn5frLpoNRLdFYW76cJ4ok2SmIKzTFq57Q=' 'sha256-ciREV5hbiDCRpVWah2irtNbfqy9H2pRaA/FB5FiJ/28=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' 'sha256-441zG27rExd4/il+NvIqyL8zFx5XmyNQtE381kSkUJk=' 'sha256-nzTgYzXYDNe6BAHiiI7NNlfK8n/auuOAhh2t92YvuXo=' 'sha256-kAApudxpTi9mfjlC9lC8ZaS9xFHU9/NLLbB173MU7SU='; img-src 'self' blob: https://www.osbytes.io;";
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "typecheck": "turbo typecheck",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "test:e2e": "pnpm --filter @crypt.fyi/web test:e2e",
     "redis": "docker compose run --rm -p 6379:6379 -v ./redis-data:/data redis redis-server --save 1 1 --loglevel notice",
     "changeset": "changeset",
     "version-packages": "changeset version",

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['<rootDir>/src/**/*.test.ts'],
   moduleFileExtensions: ['ts', 'js', 'json'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 };

--- a/packages/core/jest.setup.ts
+++ b/packages/core/jest.setup.ts
@@ -1,0 +1,5 @@
+import { useFastKdfForTests } from './src/kdf';
+
+// Production Argon2id / PBKDF2 params make pure-JS unit tests take minutes;
+// keep algorithm coverage, drop work factors for this suite only.
+useFastKdfForTests();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -61,21 +61,14 @@ describe('Client create -> read round trip', () => {
     expect(read.c).toBe('hello world');
   });
 
-  it('round-trips content with a password (versioned key + argon2 hash)', async () => {
+  it('round-trips with a password and rejects wrong / missing password', async () => {
     const created = await client.create({ c: 'the secret', p: 'hunter2', ttl: 1000, b: false });
     expect(created.key.startsWith('2.')).toBe(true);
 
     const read = await client.read(created.id, created.key, 'hunter2');
     expect(read.c).toBe('the secret');
-  });
 
-  it('rejects a read with the wrong password', async () => {
-    const created = await client.create({ c: 'the secret', p: 'hunter2', ttl: 1000, b: false });
     await expect(client.read(created.id, created.key, 'wrong')).rejects.toThrow();
-  });
-
-  it('rejects a read missing the required password', async () => {
-    const created = await client.create({ c: 'the secret', p: 'hunter2', ttl: 1000, b: false });
     await expect(client.read(created.id, created.key)).rejects.toThrow();
   });
 

--- a/packages/core/src/encryption/gcm.ts
+++ b/packages/core/src/encryption/gcm.ts
@@ -5,17 +5,17 @@ import { randomBytes } from '@noble/hashes/utils';
 import { concatBytes, utf8ToBytes } from '@noble/hashes/utils';
 import { Decrypt, Encrypt, DecryptError, EncryptError } from './encryption';
 import { Buffer } from '../buffer';
+import { getPbkdf2Iterations } from '../kdf';
 
 const SALT_LENGTH = 16;
 const IV_LENGTH = 12;
 const KEY_LENGTH = 32;
-const ITERATIONS = 2 ** 19;
 
 export const encrypt: Encrypt = async (content, password) => {
   try {
     const salt = randomBytes(SALT_LENGTH);
     const key = await pbkdf2Async(nobleSha256, utf8ToBytes(password), salt, {
-      c: ITERATIONS,
+      c: getPbkdf2Iterations(),
       dkLen: KEY_LENGTH,
     });
     const iv = randomBytes(IV_LENGTH);
@@ -37,7 +37,7 @@ export const decrypt: Decrypt = async (encryptedContent, password) => {
     const ciphertext = data.subarray(SALT_LENGTH + IV_LENGTH);
 
     const key = await pbkdf2Async(nobleSha256, utf8ToBytes(password), salt, {
-      c: ITERATIONS,
+      c: getPbkdf2Iterations(),
       dkLen: KEY_LENGTH,
     });
 

--- a/packages/core/src/encryption/index.test.ts
+++ b/packages/core/src/encryption/index.test.ts
@@ -22,17 +22,13 @@ describe('encryption', () => {
   const testData = 'Hello, World!';
   const testPassword = 'test-password-123';
 
-  it.each(algorithms)('should successfully encrypt and decrypt data $name', async (algorithm) => {
-    const encrypted = await algorithm.encrypt(testData, testPassword);
-    expect(encrypted).not.toBe(testData);
-
-    const decrypted = await algorithm.decrypt(encrypted, testPassword);
-    expect(decrypted).toBe(testData);
-  });
-
-  it.each(algorithms)('should fail to decrypt with wrong password $name', async (algorithm) => {
-    const encrypted = await algorithm.encrypt(testData, testPassword);
-
-    await expect(algorithm.decrypt(encrypted, 'wrong-password')).rejects.toThrow();
-  });
+  it.each(algorithms)(
+    'should round-trip and fail decrypt with wrong password $name',
+    async (algorithm) => {
+      const encrypted = await algorithm.encrypt(testData, testPassword);
+      expect(encrypted).not.toBe(testData);
+      expect(await algorithm.decrypt(encrypted, testPassword)).toBe(testData);
+      await expect(algorithm.decrypt(encrypted, 'wrong-password')).rejects.toThrow();
+    },
+  );
 });

--- a/packages/core/src/encryption/mlkem_argon2.test.ts
+++ b/packages/core/src/encryption/mlkem_argon2.test.ts
@@ -1,19 +1,14 @@
 import { encrypt, decrypt } from './mlkem_argon2';
 
 describe('ml-kem-768-argon2', () => {
-  it('round-trips content with a password', async () => {
-    const enc = await encrypt('top secret', 'correct horse battery staple');
-    expect(await decrypt(enc, 'correct horse battery staple')).toBe('top secret');
-  });
+  it('round-trips, is non-deterministic, and rejects the wrong password', async () => {
+    const password = 'correct horse battery staple';
+    const enc = await encrypt('top secret', password);
+    expect(await decrypt(enc, password)).toBe('top secret');
 
-  it('produces distinct ciphertexts for the same input', async () => {
-    const a = await encrypt('same', 'pw');
-    const b = await encrypt('same', 'pw');
-    expect(a).not.toBe(b);
-  });
+    const again = await encrypt('top secret', password);
+    expect(again).not.toBe(enc);
 
-  it('fails to decrypt with the wrong password', async () => {
-    const enc = await encrypt('secret', 'right');
     await expect(decrypt(enc, 'wrong')).rejects.toThrow();
   });
 });

--- a/packages/core/src/encryption/mlkem_argon2.ts
+++ b/packages/core/src/encryption/mlkem_argon2.ts
@@ -4,6 +4,7 @@ import { concatBytes, utf8ToBytes } from '@noble/hashes/utils';
 import { argon2idAsync } from '@noble/hashes/argon2';
 import { chacha20poly1305 } from '@noble/ciphers/chacha';
 import { Buffer } from '../buffer';
+import { getArgon2ContentParams } from '../kdf';
 import { Decrypt, Encrypt, DecryptError, EncryptError } from './encryption';
 
 // ml-kem-768-argon2: identical construction to ml-kem-768-2 (ML-KEM-768 KEM +
@@ -12,21 +13,13 @@ import { Decrypt, Encrypt, DecryptError, EncryptError } from './encryption';
 // memory-hard KDF materially raises the cost of offline brute-force.
 //
 // Argon2id parameters follow the OWASP minimum for interactive use, tuned to
-// stay usable in-browser with the pure-JS noble implementation.
+// stay usable in-browser with the pure-JS noble implementation. See kdf.ts.
 const IV_LENGTH = 12;
 const CIPHERTEXT_LENGTH = 1088;
 const SALT_LENGTH = 32;
-const SEED_LENGTH = 64; // ml_kem768.keygen expects a 64-byte seed
-
-const ARGON2_PARAMS = {
-  t: 2, // iterations (time cost)
-  m: 19456, // 19 MiB (memory cost, in KiB)
-  p: 1, // parallelism
-  dkLen: SEED_LENGTH,
-} as const;
 
 const deriveKey = async (password: string, salt: Uint8Array): Promise<Uint8Array> => {
-  return argon2idAsync(utf8ToBytes(password), salt, ARGON2_PARAMS);
+  return argon2idAsync(utf8ToBytes(password), salt, getArgon2ContentParams());
 };
 
 export const encrypt: Encrypt = async (content: string, password: string) => {

--- a/packages/core/src/kdf.ts
+++ b/packages/core/src/kdf.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared KDF parameters for Argon2id (password layer + v2 verification) and
+ * legacy PBKDF2-GCM. Production values stay hard by default.
+ *
+ * Unit tests call {@link useFastKdfForTests} from Jest setup so CI isn't dominated
+ * by pure-JS Argon2 / PBKDF2 cost. Ciphertext formats and algorithms are unchanged;
+ * only the work factor drops.
+ */
+
+export type Argon2Params = {
+  t: number;
+  m: number;
+  p: number;
+  dkLen: number;
+};
+
+/** OWASP interactive minimum; tuned for in-browser noble Argon2id. */
+export const PRODUCTION_ARGON2_CONTENT: Argon2Params = {
+  t: 2,
+  m: 19456, // 19 MiB
+  p: 1,
+  dkLen: 64, // ML-KEM-768 seed
+};
+
+export const PRODUCTION_ARGON2_VERIFICATION: Argon2Params = {
+  t: 2,
+  m: 19456, // 19 MiB
+  p: 1,
+  dkLen: 32,
+};
+
+/** Legacy AES-GCM password stretching (2^19). */
+export const PRODUCTION_PBKDF2_ITERATIONS = 2 ** 19;
+
+// Minimal Argon2id work: still exercises the real KDF path without ~19 MiB / t=2.
+const FAST_ARGON2_BASE = { t: 1, m: 8, p: 1 } as const;
+const FAST_PBKDF2_ITERATIONS = 1_000;
+
+let argon2Content: Argon2Params = { ...PRODUCTION_ARGON2_CONTENT };
+let argon2Verification: Argon2Params = { ...PRODUCTION_ARGON2_VERIFICATION };
+let pbkdf2Iterations = PRODUCTION_PBKDF2_ITERATIONS;
+
+export const getArgon2ContentParams = (): Argon2Params => argon2Content;
+export const getArgon2VerificationParams = (): Argon2Params => argon2Verification;
+export const getPbkdf2Iterations = (): number => pbkdf2Iterations;
+
+/**
+ * Drop KDF work factors for unit tests. Must not be called from production code paths.
+ */
+export const useFastKdfForTests = (): void => {
+  argon2Content = { ...FAST_ARGON2_BASE, dkLen: PRODUCTION_ARGON2_CONTENT.dkLen };
+  argon2Verification = { ...FAST_ARGON2_BASE, dkLen: PRODUCTION_ARGON2_VERIFICATION.dkLen };
+  pbkdf2Iterations = FAST_PBKDF2_ITERATIONS;
+};

--- a/packages/core/src/verification.test.ts
+++ b/packages/core/src/verification.test.ts
@@ -17,21 +17,12 @@ describe('deriveVerificationHash', () => {
     expect(await deriveVerificationHash('legacy', 'thekey')).toBe(sha512('thekey'));
   });
 
-  it('v2 scheme is deterministic for the same inputs (reproducible at read)', async () => {
+  it('v2 is deterministic, differs from legacy/other password, and binds salt to the key', async () => {
     const a = await deriveVerificationHash('v2', 'thekey', 'pw');
     const b = await deriveVerificationHash('v2', 'thekey', 'pw');
     expect(a).toBe(b);
-  });
-
-  it('v2 differs from legacy and from a different password', async () => {
-    const v2 = await deriveVerificationHash('v2', 'thekey', 'pw');
-    expect(v2).not.toBe(sha512('thekey' + 'pw'));
-    expect(v2).not.toBe(await deriveVerificationHash('v2', 'thekey', 'other'));
-  });
-
-  it('v2 salt is bound to the key (different key => different hash even with same password)', async () => {
-    const a = await deriveVerificationHash('v2', 'key-a', 'pw');
-    const b = await deriveVerificationHash('v2', 'key-b', 'pw');
-    expect(a).not.toBe(b);
+    expect(a).not.toBe(sha512('thekey' + 'pw'));
+    expect(a).not.toBe(await deriveVerificationHash('v2', 'thekey', 'other'));
+    expect(a).not.toBe(await deriveVerificationHash('v2', 'key-b', 'pw'));
   });
 });

--- a/packages/core/src/verification.ts
+++ b/packages/core/src/verification.ts
@@ -3,6 +3,7 @@ import { sha256 as nobleSha256 } from '@noble/hashes/sha2';
 import { utf8ToBytes } from '@noble/hashes/utils';
 import { Buffer } from './buffer';
 import { sha512 } from './hash';
+import { getArgon2VerificationParams } from './kdf';
 
 // The server-stored verification hash `h` proves the reader possesses the URL
 // key without revealing it. The legacy scheme (`sha512(key + password)`) is fast
@@ -18,15 +19,9 @@ import { sha512 } from './hash';
 // The scheme is selected by a version prefix embedded in the URL-fragment key
 // itself (`2.<rawKey>`), so callers keep treating the key as an opaque string
 // and legacy links (bare `<rawKey>`) continue to verify with the old scheme.
+// Production Argon2id params live in kdf.ts.
 
 export const KEY_VERSION_2_PREFIX = '2.';
-
-const ARGON2_PARAMS = {
-  t: 2,
-  m: 19456, // 19 MiB
-  p: 1,
-  dkLen: 32,
-} as const;
 
 /** Splits a URL-fragment key into its verification scheme and the raw key used for content crypto. */
 export const parseKey = (key: string): { scheme: 'legacy' | 'v2'; rawKey: string } => {
@@ -47,6 +42,6 @@ export const deriveVerificationHash = async (
     return sha512(secret);
   }
   const salt = nobleSha256(utf8ToBytes(rawKey));
-  const derived = await argon2idAsync(utf8ToBytes(secret), salt, ARGON2_PARAMS);
+  const derived = await argon2idAsync(utf8ToBytes(secret), salt, getArgon2VerificationParams());
   return Buffer.from(derived).toString('hex');
 };

--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -11,6 +11,10 @@ node_modules
 dist
 dist-ssr
 *.local
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
 
 # Editor directories and files
 .vscode/*

--- a/packages/web/csp.ts
+++ b/packages/web/csp.ts
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const nginxConfPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../nginx/nginx.conf',
+);
+
+/**
+ * Read the production CSP from nginx.conf and substitute `$api_url`.
+ * Keeps preview/e2e policy in lockstep with what we ship — no library-specific
+ * hash allowlists maintained in a second place.
+ */
+export function loadProductionCsp(apiUrl: string): string {
+  const nginxConf = fs.readFileSync(nginxConfPath, 'utf8');
+  const cspMatch = nginxConf.match(/add_header\s+Content-Security-Policy\s+"([^"]*)"/);
+  if (!cspMatch) {
+    throw new Error(`Content-Security-Policy header not found in ${nginxConfPath}`);
+  }
+  return cspMatch[1].replaceAll('$api_url', apiUrl);
+}

--- a/packages/web/e2e/create-read.spec.ts
+++ b/packages/web/e2e/create-read.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from './fixtures';
+
+const SECRET = `playwright-smoke-${Date.now()}`;
+
+/** Violations that break the product or the reason we added this smoke. */
+const isBlockingCspViolation = (directive: string) =>
+  directive === 'connect-src' || directive.startsWith('style-src');
+
+test.describe('create and read smoke', () => {
+  test('creates a secret and reads it back under production CSP', async ({
+    page,
+    consoleEntries,
+    cspViolations,
+  }, testInfo) => {
+    // Ensure console fixture is active for the whole test (reporting is non-blocking).
+    void consoleEntries;
+
+    await page.goto('/new');
+
+    await page.getByLabel('Secret content').fill(SECRET);
+    await page.getByRole('button', { name: 'Create' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Secret Created!' })).toBeVisible();
+
+    // Unmask before reading the value (success fields are masked by default).
+    await page.getByRole('button', { name: 'Show secret URL' }).first().click();
+    const combinedUrl = await page.locator('#combined-url').inputValue();
+    expect(combinedUrl).toMatch(/\/[^/#?\s]+#/);
+
+    // Exercise toast styling paths that often trip style-src.
+    await page.getByRole('button', { name: 'Copy secret URL' }).first().click();
+
+    await page.goto(combinedUrl);
+    await page.getByRole('button', { name: 'View Secret' }).click();
+
+    await expect(page.getByLabel('Secret content')).toHaveText(SECRET);
+
+    const blocking = cspViolations.filter((v) => isBlockingCspViolation(v.effectiveDirective));
+    const reported = cspViolations.filter((v) => !isBlockingCspViolation(v.effectiveDirective));
+
+    if (reported.length > 0) {
+      const summary = reported
+        .map(
+          (v) =>
+            `[${v.effectiveDirective}] blocked ${v.blockedURI || '(inline)'} @ ${v.sourceFile}:${v.lineNumber}`,
+        )
+        .join('\n');
+      testInfo.annotations.push({
+        type: 'csp',
+        description: `${reported.length} non-blocking CSP violation(s):\n${summary}`,
+      });
+      console.warn(`\n[smoke] non-blocking CSP noise (${reported.length}):\n${summary}\n`);
+    }
+
+    expect(
+      blocking,
+      blocking.length
+        ? `Blocking CSP violation(s) under production policy:\n${blocking
+            .map(
+              (v) =>
+                `- ${v.effectiveDirective} blocked ${v.blockedURI || '(inline)'} @ ${v.sourceFile}:${v.lineNumber}`,
+            )
+            .join('\n')}\nUpdate nginx/nginx.conf (or fix the offender), then re-run.`
+        : '',
+    ).toEqual([]);
+  });
+});

--- a/packages/web/e2e/fixtures.ts
+++ b/packages/web/e2e/fixtures.ts
@@ -1,0 +1,121 @@
+import { test as base, expect, type ConsoleMessage, type Page } from '@playwright/test';
+
+export type ConsoleEntry = {
+  type: string;
+  text: string;
+  location?: string;
+};
+
+export type CspViolation = {
+  effectiveDirective: string;
+  blockedURI: string;
+  violatedDirective: string;
+  originalPolicy: string;
+  sourceFile: string;
+  lineNumber: number;
+  columnNumber: number;
+};
+
+type SmokeFixtures = {
+  consoleEntries: ConsoleEntry[];
+  cspViolations: CspViolation[];
+};
+
+/**
+ * Console noise is collected for reporting and never fails the test by itself.
+ * CSP violations are tracked separately and asserted in the smoke test — that is
+ * the library-agnostic stand-in for hashing specific dependency payloads.
+ */
+export const test = base.extend<SmokeFixtures>({
+  consoleEntries: async ({ page }, use, testInfo) => {
+    const entries: ConsoleEntry[] = [];
+
+    const onConsole = (msg: ConsoleMessage) => {
+      entries.push({
+        type: msg.type(),
+        text: msg.text(),
+        location: msg.location().url
+          ? `${msg.location().url}:${msg.location().lineNumber}`
+          : undefined,
+      });
+    };
+    const onPageError = (error: Error) => {
+      entries.push({ type: 'pageerror', text: error.message });
+    };
+
+    page.on('console', onConsole);
+    page.on('pageerror', onPageError);
+
+    await use(entries);
+
+    page.off('console', onConsole);
+    page.off('pageerror', onPageError);
+
+    const notable = entries.filter((e) =>
+      ['warning', 'error', 'assert', 'pageerror'].includes(e.type),
+    );
+
+    const report = {
+      total: entries.length,
+      notable,
+      all: entries,
+    };
+
+    await testInfo.attach('console-report.json', {
+      body: JSON.stringify(report, null, 2),
+      contentType: 'application/json',
+    });
+
+    if (notable.length > 0) {
+      const summary = notable.map((e) => `[${e.type}] ${e.text}`).join('\n');
+      testInfo.annotations.push({
+        type: 'console',
+        description: `${notable.length} non-blocking console warning(s)/error(s):\n${summary}`,
+      });
+      // Soft report only — do not fail the test.
+      console.warn(`\n[smoke] non-blocking console noise (${notable.length}):\n${summary}\n`);
+    }
+  },
+
+  cspViolations: async ({ page }, use) => {
+    const violations: CspViolation[] = [];
+    await installCspViolationListener(page, violations);
+    await use(violations);
+  },
+});
+
+export { expect };
+
+async function installCspViolationListener(page: Page, sink: CspViolation[]) {
+  await page.exposeBinding('__cryptFyiReportCspViolation', ({}, violation: CspViolation) => {
+    sink.push(violation);
+  });
+
+  await page.addInitScript(() => {
+    document.addEventListener('securitypolicyviolation', (event) => {
+      const report = (
+        window as Window & {
+          __cryptFyiReportCspViolation?: (v: {
+            effectiveDirective: string;
+            blockedURI: string;
+            violatedDirective: string;
+            originalPolicy: string;
+            sourceFile: string;
+            lineNumber: number;
+            columnNumber: number;
+          }) => void;
+        }
+      ).__cryptFyiReportCspViolation;
+
+      report?.({
+        effectiveDirective: event.effectiveDirective,
+        blockedURI: event.blockedURI,
+        violatedDirective: event.violatedDirective,
+        originalPolicy: event.originalPolicy,
+        sourceFile: event.sourceFile,
+        lineNumber: event.lineNumber,
+        columnNumber: event.columnNumber,
+      });
+    });
+  });
+}

--- a/packages/web/e2e/fixtures.ts
+++ b/packages/web/e2e/fixtures.ts
@@ -27,7 +27,9 @@ type SmokeFixtures = {
  * the library-agnostic stand-in for hashing specific dependency payloads.
  */
 export const test = base.extend<SmokeFixtures>({
-  consoleEntries: async ({ page }, use, testInfo) => {
+  // Rename Playwright's fixture `use` callback — eslint-plugin-react-hooks
+  // otherwise treats it as React's `use` hook.
+  consoleEntries: async ({ page }, provide, testInfo) => {
     const entries: ConsoleEntry[] = [];
 
     const onConsole = (msg: ConsoleMessage) => {
@@ -46,7 +48,7 @@ export const test = base.extend<SmokeFixtures>({
     page.on('console', onConsole);
     page.on('pageerror', onPageError);
 
-    await use(entries);
+    await provide(entries);
 
     page.off('console', onConsole);
     page.off('pageerror', onPageError);
@@ -77,17 +79,17 @@ export const test = base.extend<SmokeFixtures>({
     }
   },
 
-  cspViolations: async ({ page }, use) => {
+  cspViolations: async ({ page }, provide) => {
     const violations: CspViolation[] = [];
     await installCspViolationListener(page, violations);
-    await use(violations);
+    await provide(violations);
   },
 });
 
 export { expect };
 
 async function installCspViolationListener(page: Page, sink: CspViolation[]) {
-  await page.exposeBinding('__cryptFyiReportCspViolation', ({}, violation: CspViolation) => {
+  await page.exposeBinding('__cryptFyiReportCspViolation', (_source, violation: CspViolation) => {
     sink.push(violation);
   });
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run --passWithNoTests",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@crypt.fyi/core": "workspace:*",
@@ -66,6 +67,7 @@
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.41.0",
     "vite": "^8.0.16",
-    "vitest": "4.1.0"
+    "vitest": "4.1.0",
+    "@playwright/test": "1.62.1"
   }
 }

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -1,0 +1,63 @@
+import { defineConfig, devices } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadProductionCsp } from './csp';
+
+const webRoot = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(webRoot, '../..');
+const apiUrl = process.env.VITE_API_URL ?? 'http://localhost:4321';
+const webPort = Number(process.env.PLAYWRIGHT_WEB_PORT ?? 4173);
+const webOrigin = `http://localhost:${webPort}`;
+const apiPort = new URL(apiUrl).port || '4321';
+const previewCsp = loadProductionCsp(apiUrl);
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  use: {
+    baseURL: webOrigin,
+    locale: 'en-US',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: [
+    {
+      command: `node "${path.join(repoRoot, 'packages/server/dist/index.js')}"`,
+      url: `${apiUrl.replace(/\/$/, '')}/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...process.env,
+        NODE_ENV: 'development',
+        REDIS_URL: process.env.REDIS_URL ?? 'redis://127.0.0.1:6379',
+        CORS_ORIGIN: '*',
+        PORT: apiPort,
+        // Smoke can re-run quickly; don't trip the default 10 req/min vault limit.
+        RATE_LIMIT_MAX: process.env.RATE_LIMIT_MAX ?? '1000',
+      },
+    },
+    {
+      command: `pnpm exec vite preview --host localhost --port ${webPort}`,
+      cwd: webRoot,
+      url: webOrigin,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...process.env,
+        VITE_API_URL: apiUrl,
+        CRYPT_FYI_PREVIEW_CSP: previewCsp,
+      },
+    },
+  ],
+});

--- a/packages/web/tsconfig.node.json
+++ b/packages/web/tsconfig.node.json
@@ -20,5 +20,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "csp.ts"]
 }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest/config" />
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,4 +1,5 @@
-import { defineConfig } from 'vite';
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import { TanStackRouterVite } from '@tanstack/router-vite-plugin';

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -59,4 +59,8 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: true,
   },
+  // Keep Playwright specs out of `pnpm test` (vitest); they run via `pnpm test:e2e`.
+  test: {
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
 });

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -5,6 +5,7 @@ import { TanStackRouterVite } from '@tanstack/router-vite-plugin';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
+import { loadProductionCsp } from './csp';
 
 const getGitHash = () => {
   if (process.env.VITE_GIT_HASH) {
@@ -21,11 +22,24 @@ const getGitHash = () => {
 
 const pkg = JSON.parse(fs.readFileSync(new URL('package.json', import.meta.url), 'utf-8'));
 
+const apiUrl = process.env.VITE_API_URL ?? 'http://localhost:4321';
+// Prefer an explicit override (Playwright sets this) so preview matches nginx.
+const previewCsp = process.env.CRYPT_FYI_PREVIEW_CSP ?? loadProductionCsp(apiUrl);
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), TanStackRouterVite(), svgr()],
   server: {
     port: 5173,
+  },
+  preview: {
+    // Smoke/e2e exercises the same CSP string nginx ships, with $api_url resolved.
+    headers: {
+      'Content-Security-Policy': previewCsp,
+      'X-Content-Type-Options': 'nosniff',
+      'Referrer-Policy': 'no-referrer',
+      'X-Frame-Options': 'DENY',
+    },
   },
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,16 @@ overrides:
   glob@>=10.2.0 <10.5.0: '>=10.5.0'
   glob@>=11.0.0 <11.1.0: '>=11.1.0'
   undici@>=6.25.0 <6.27.0: 6.27.0
-  js-yaml@3: 3.15.0
-  js-yaml@4: 4.3.0
+  js-yaml@3: 3.15.1
+  js-yaml@4: 4.3.1
+  brace-expansion@<1.1.18: ^1.1.18
+  brace-expansion@>=2.0.0 <2.1.4: ^2.1.4
+  brace-expansion@>=4.0.0 <5.0.9: ^5.0.9
+  fast-uri@>=3.0.0 <3.1.5: ^3.1.5
+  fast-uri@>=4.0.0 <4.1.2: ^4.1.2
+  js-yaml@>=3.0.0 <3.15.1: ^3.15.1
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
+  nanoid@<3.3.17: ^3.3.17
 
 importers:
 
@@ -457,6 +465,9 @@ importers:
       '@eslint/js':
         specifier: ^9.34.0
         version: 9.39.2
+      '@playwright/test':
+        specifier: 1.62.1
+        version: 1.62.1
       '@tailwindcss/postcss':
         specifier: ^4.1.12
         version: 4.3.3
@@ -2289,6 +2300,11 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
     engines: {node: '>=12.22.0'}
@@ -3882,14 +3898,14 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -4538,11 +4554,11 @@ packages:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -4662,6 +4678,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -4917,6 +4938,7 @@ packages:
 
   ip-range-check@0.2.0:
     resolution: {integrity: sha512-oaM3l/3gHbLlt/tCWLvt0mj1qUaI+STuRFnUvARGCujK9vvU61+2JsDpmkMzR4VsJhuFXWWgeKKVnwwoFfzCqw==}
+    deprecated: Contains an SSRF filter-bypass vulnerability, upgrade to 0.2.1+ — see GHSA advisory
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -5211,12 +5233,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5657,8 +5679,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5917,6 +5939,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -8036,7 +8068,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -8215,7 +8247,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -8236,7 +8268,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
 
   '@fastify/compress@8.3.1':
     dependencies:
@@ -8391,7 +8423,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -9428,6 +9460,10 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.3.6': {}
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -10763,7 +10799,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10958,16 +10994,16 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11216,7 +11252,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.2):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -11604,7 +11640,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -11616,9 +11652,9 @@ snapshots:
 
   fast-redact@3.5.0: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fastify-plugin@5.1.0: {}
 
@@ -11765,6 +11801,9 @@ snapshots:
       universalify: 0.1.2
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -12476,12 +12515,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -12504,7 +12543,7 @@ snapshots:
   json-schema-resolver@3.0.0(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color
@@ -12786,15 +12825,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -12858,7 +12897,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -13134,6 +13173,14 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.23)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
@@ -13144,7 +13191,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -13301,7 +13348,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       pify: 4.0.1
       strip-bom: 3.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,11 @@ packages:
 minimumReleaseAge: 1440 # 1 day
 minimumReleaseAgeExclude:
   - '@crypt.fyi/*'
+  - brace-expansion@1.1.18 || 2.1.4 || 5.0.9
+  - fast-uri@3.1.5 || 4.1.2
+  - js-yaml@3.15.1 || 4.3.1
+  - nanoid@3.3.17
+  - '@playwright/test'
 
 # Block transitive git/http/file/link/portal dependencies from external packages.
 blockExoticSubdeps: true
@@ -64,5 +69,18 @@ overrides:
   'glob@>=10.2.0 <10.5.0': '>=10.5.0'
   'glob@>=11.0.0 <11.1.0': '>=11.1.0'
   'undici@>=6.25.0 <6.27.0': 6.27.0
-  'js-yaml@3': 3.15.0
-  'js-yaml@4': 4.3.0
+  # Prefer exact patched majors; range overrides below catch other semver shapes.
+  'js-yaml@3': 3.15.1
+  'js-yaml@4': 4.3.1
+  # GHSA-mh99-v99m-4gvg / GHSA-rgw5-rvv9-x895 (brace-expansion DoS)
+  brace-expansion@<1.1.18: ^1.1.18
+  brace-expansion@>=2.0.0 <2.1.4: ^2.1.4
+  brace-expansion@>=4.0.0 <5.0.9: ^5.0.9
+  # GHSA-7p8r-x3mc-p8w7 (fast-uri host confusion)
+  fast-uri@>=3.0.0 <3.1.5: ^3.1.5
+  fast-uri@>=4.0.0 <4.1.2: ^4.1.2
+  # GHSA-5p4m-2wfm-xmqj (js-yaml !!omap DoS) — covers non-major selectors too
+  js-yaml@>=3.0.0 <3.15.1: ^3.15.1
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
+  # GHSA-2v37-7h3g-55p8 (nanoid infinite loop on size 0)
+  nanoid@<3.3.17: ^3.3.17


### PR DESCRIPTION
## Summary
- Add a Playwright create→read smoke that serves the nginx CSP via `vite preview`, fails on `style-src` / `connect-src` violations, and reports other console/CSP noise as non-blocking annotations
- Update nginx CSP with the current sonner stylesheet hash and explicit `script-src 'self'`
- Pin transitive security overrides (brace-expansion, fast-uri, js-yaml, nanoid) so `pnpm audit` is clean

## Test plan
- [ ] `pnpm build`
- [ ] Start Redis, then `pnpm test:e2e` — create/read passes; style-src/connect-src clean
- [ ] Confirm CI runs Install Playwright Chromium + E2E smoke after unit tests
- [ ] Spot-check that a missing style-src hash fails the smoke with a useful message
- [ ] `pnpm audit` reports no known vulnerabilities
