### PR TITLE
feat(extension): add options page and managed config defaults

### DIFF
--- a/.changeset/extension-default-config.md
+++ b/.changeset/extension-default-config.md
@@ -1,5 +1,5 @@
 ---
-'@crypt.fyi/extension': minor
+'@crypt.fyi/extension': patch
 ---
 
 Add an options page and managed-storage defaults for the browser extension so users and admins can configure create settings without rebuilding.

--- a/.changeset/extension-default-config.md
+++ b/.changeset/extension-default-config.md
@@ -1,0 +1,5 @@
+---
+'@crypt.fyi/extension': minor
+---
+
+Add an options page and managed-storage defaults for the browser extension so users and admins can configure create settings without rebuilding.

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -63,7 +63,9 @@ Precedence for each setting: **your saved options → organization managed polic
 | `webhookUrl` / `webhookName` | Webhook target and label |
 | `webhookOnRead` / `webhookOnFailPassword` / `webhookOnFailIp` / `webhookOnBurn` | Webhook events |
 
-Open settings from the extension toolbar icon, or via the browser’s extension details → Options. Use **Export / Import JSON** to share a config file with self-hosters who are not on managed browsers. **Reset to defaults** clears your overrides so managed/build values apply again.
+Open settings from the extension toolbar icon, or via the browser’s extension details → Options. Use **Export / Import JSON** to share a config file with self-hosters who are not on managed browsers. **Import replaces all saved overrides** (omitted keys fall back to managed/build). Export writes the full effective snapshot, including `null` for cleared optionals so round-trips keep those clears. **Reset to defaults** clears your overrides so managed/build values apply again.
+
+`apiUrl` / `webUrl` / `webhookUrl` must be public http(s) URLs (no private/reserved literal IPs or internal hostnames such as `localhost`). Self-host on a public hostname, or build a branded extension with `VITE_API_URL` / `VITE_WEB_URL`.
 
 ### Chrome enterprise (seed defaults)
 
@@ -97,6 +99,8 @@ Use `policies.json` `3rdparty.Extensions` as in [`examples/firefox-policies.json
 - The encrypted content is sent to the configured API host
 - Default create options burn after reading with a 30-minute TTL unless overridden
 - Pointing `apiUrl` / `webUrl` at non-default hosts changes who receives ciphertext and who hosts the share UI — only use hosts you trust
+- Invalid configured endpoints are not silently replaced by the public defaults during encrypt; fix the options/policy error first
+- Organization `storage.managed` values are **seed defaults**, not locks — users can override them in Options unless you ship a custom build
 
 ## License
 

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -8,6 +8,10 @@ This browser extension allows you to quickly encrypt and share text selections u
 - Secure encryption using crypt.fyi's encryption standards
 - Automatic clipboard copying of encrypted URLs
 - Desktop notifications for successful encryption and errors
+- Options page for default create settings (endpoints, TTL, burn, IP allow-list, read/failure counts, webhooks)
+- Organization policy seeding via `storage.managed` (Chrome / Firefox enterprise)
+
+Password defaults are intentionally not supported — use the web app when a password is required.
 
 ## Development
 
@@ -20,7 +24,7 @@ pnpm install
 2. Start the development server:
 
 ```bash
-pnpm dev
+pnpm --filter @crypt.fyi/extension dev
 ```
 
 3. Load the extension in your browser:
@@ -37,27 +41,62 @@ pnpm dev
 
 ## Building
 
-To build the extension for production:
-
 ```bash
-pnpm build
+pnpm --filter @crypt.fyi/extension build
 ```
 
 The built extension will be in the `dist` directory.
 
+## Configuration
+
+Precedence for each setting: **your saved options → organization managed policy → built-in defaults**.
+
+| Key | Description |
+|-----|-------------|
+| `apiUrl` | API base URL |
+| `webUrl` | Share-link base URL |
+| `ttl` | TTL in ms (one of the supported durations) |
+| `burn` | Burn after reading |
+| `ips` | Comma-separated IP/CIDR allow-list (max 3) |
+| `rc` | Max successful reads (2–10; only when `burn` is false) |
+| `fc` | Burn after N failed attempts (1–10) |
+| `webhookUrl` / `webhookName` | Webhook target and label |
+| `webhookOnRead` / `webhookOnFailPassword` / `webhookOnFailIp` / `webhookOnBurn` | Webhook events |
+
+Open settings from the extension toolbar icon, or via the browser’s extension details → Options. Use **Export / Import JSON** to share a config file with self-hosters who are not on managed browsers. **Reset to defaults** clears your overrides so managed/build values apply again.
+
+### Chrome enterprise (seed defaults)
+
+1. Force-install or allow the extension for your org.
+2. Set **Policy for extensions** using the shape in [`examples/chrome-extension-policy.json`](./examples/chrome-extension-policy.json) (Chrome expects `{ "key": { "Value": ... } }`).
+3. Confirm policies at `chrome://policy`. The extension schema is shipped as `managed_schema.json`.
+
+### Firefox enterprise (seed defaults)
+
+Use `policies.json` `3rdparty.Extensions` as in [`examples/firefox-policies.json`](./examples/firefox-policies.json). Replace the extension ID with your signed add-on ID. Firefox may require a browser restart before `storage.managed` updates appear.
+
+### Build-time env (last resort / branded builds)
+
+| Variable | Default |
+|----------|---------|
+| `VITE_API_URL` | `https://api.crypt.fyi` |
+| `VITE_WEB_URL` | `https://crypt.fyi` |
+| `VITE_DEFAULT_TTL` | `1800000` (30 minutes) |
+| `VITE_KEY_LENGTH` | `32` |
+
 ## Usage
 
 1. Select any text on a webpage
-2. Right-click and select "Encrypt with crypt.fyi"
-3. The encrypted URL will be automatically copied to your clipboard
+2. Right-click and select **Encrypt and Share with crypt.fyi**
+3. The encrypted URL is copied to your clipboard using your configured defaults
 4. Share the URL with your recipient
 
 ## Security
 
 - All encryption is performed locally in your browser
-- The encrypted content is sent to crypt.fyi servers
-- URLs are automatically set to burn after reading
-- Default TTL is 30 minutes
+- The encrypted content is sent to the configured API host
+- Default create options burn after reading with a 30-minute TTL unless overridden
+- Pointing `apiUrl` / `webUrl` at non-default hosts changes who receives ciphertext and who hosts the share UI — only use hosts you trust
 
 ## License
 

--- a/packages/extension/examples/chrome-extension-policy.json
+++ b/packages/extension/examples/chrome-extension-policy.json
@@ -1,0 +1,32 @@
+{
+  "apiUrl": {
+    "Value": "https://api.example.com"
+  },
+  "webUrl": {
+    "Value": "https://secrets.example.com"
+  },
+  "ttl": {
+    "Value": 3600000
+  },
+  "burn": {
+    "Value": true
+  },
+  "ips": {
+    "Value": "203.0.113.0/24"
+  },
+  "fc": {
+    "Value": 3
+  },
+  "webhookUrl": {
+    "Value": "https://hooks.example.com/crypt"
+  },
+  "webhookName": {
+    "Value": "corp-vault"
+  },
+  "webhookOnRead": {
+    "Value": true
+  },
+  "webhookOnBurn": {
+    "Value": true
+  }
+}

--- a/packages/extension/examples/firefox-policies.json
+++ b/packages/extension/examples/firefox-policies.json
@@ -1,0 +1,20 @@
+{
+  "policies": {
+    "3rdparty": {
+      "Extensions": {
+        "crypt.fyi@example.com": {
+          "apiUrl": "https://api.example.com",
+          "webUrl": "https://secrets.example.com",
+          "ttl": 3600000,
+          "burn": true,
+          "ips": "203.0.113.0/24",
+          "fc": 3,
+          "webhookUrl": "https://hooks.example.com/crypt",
+          "webhookName": "corp-vault",
+          "webhookOnRead": true,
+          "webhookOnBurn": true
+        }
+      }
+    }
+  }
+}

--- a/packages/extension/jest.config.js
+++ b/packages/extension/jest.config.js
@@ -1,0 +1,25 @@
+/** @type {import('jest').Config} */
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: {
+          module: 'ESNext',
+          moduleResolution: 'Node',
+          esModuleInterop: true,
+          target: 'ES2020',
+        },
+      },
+    ],
+  },
+  transformIgnorePatterns: ['/node_modules/(?!(@crypt\\.fyi)/)'],
+  testMatch: ['**/src/**/*.test.ts'],
+};

--- a/packages/extension/managed_schema.json
+++ b/packages/extension/managed_schema.json
@@ -1,0 +1,70 @@
+{
+  "type": "object",
+  "properties": {
+    "apiUrl": {
+      "title": "API URL",
+      "description": "Base URL for the crypt.fyi API (e.g. https://api.crypt.fyi).",
+      "type": "string"
+    },
+    "webUrl": {
+      "title": "Web URL",
+      "description": "Base URL used when building share links (e.g. https://crypt.fyi).",
+      "type": "string"
+    },
+    "ttl": {
+      "title": "Default TTL (milliseconds)",
+      "description": "Secret time-to-live in milliseconds. Must be one of: 300000, 1800000, 3600000, 14400000, 43200000, 86400000, 259200000, 604800000.",
+      "type": "integer"
+    },
+    "burn": {
+      "title": "Burn after reading",
+      "description": "When true, secrets are deleted after the first successful read. Incompatible with read count (rc).",
+      "type": "boolean"
+    },
+    "ips": {
+      "title": "IP / CIDR allow-list",
+      "description": "Comma-separated IP addresses or CIDR blocks allowed to read the secret (max 3).",
+      "type": "string"
+    },
+    "rc": {
+      "title": "Read count",
+      "description": "Maximum number of successful reads (2–10). Only used when burn is false.",
+      "type": "integer"
+    },
+    "fc": {
+      "title": "Failure count",
+      "description": "Burn after this many failed read attempts (1–10).",
+      "type": "integer"
+    },
+    "webhookUrl": {
+      "title": "Webhook URL",
+      "description": "Public http(s) URL for vault event notifications. Must not target private/reserved addresses.",
+      "type": "string"
+    },
+    "webhookName": {
+      "title": "Webhook name",
+      "description": "Optional label included in webhook notifications (max 50 characters).",
+      "type": "string"
+    },
+    "webhookOnRead": {
+      "title": "Webhook on read",
+      "description": "Notify when the secret is read successfully.",
+      "type": "boolean"
+    },
+    "webhookOnFailPassword": {
+      "title": "Webhook on password/key failure",
+      "description": "Notify when a read fails due to password or key.",
+      "type": "boolean"
+    },
+    "webhookOnFailIp": {
+      "title": "Webhook on IP failure",
+      "description": "Notify when a read fails due to IP allow-list.",
+      "type": "boolean"
+    },
+    "webhookOnBurn": {
+      "title": "Webhook on burn",
+      "description": "Notify when the secret is burned.",
+      "type": "boolean"
+    }
+  }
+}

--- a/packages/extension/managed_schema.json
+++ b/packages/extension/managed_schema.json
@@ -3,12 +3,12 @@
   "properties": {
     "apiUrl": {
       "title": "API URL",
-      "description": "Base URL for the crypt.fyi API (e.g. https://api.crypt.fyi).",
+      "description": "Base URL for the crypt.fyi API (e.g. https://api.crypt.fyi). Must be a public http(s) URL — private/reserved literal IPs and internal hostnames are rejected.",
       "type": "string"
     },
     "webUrl": {
       "title": "Web URL",
-      "description": "Base URL used when building share links (e.g. https://crypt.fyi).",
+      "description": "Base URL used when building share links (e.g. https://crypt.fyi). Must be a public http(s) URL — private/reserved literal IPs and internal hostnames are rejected.",
       "type": "string"
     },
     "ttl": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -6,17 +6,20 @@
   "type": "module",
   "dependencies": {
     "@crypt.fyi/core": "workspace:*",
-    "webextension-polyfill": "^0.12.0"
+    "webextension-polyfill": "^0.12.0",
+    "zod": "^4.1.5"
   },
   "scripts": {
     "dev": "cross-env VITE_API_URL=http://localhost:4321 VITE_WEB_URL=http://localhost:5173 vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint src",
-    "test": "jest --passWithNoTests",
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --passWithNoTests",
     "publish:chrome": "node ../../scripts/publish-extension.mjs"
   },
   "devDependencies": {
+    "@jest/globals": "^30.4.1",
+    "@tailwindcss/vite": "4.3.3",
     "@types/chrome": "^0.1.4",
     "@types/webextension-polyfill": "^0.12.3",
     "@typescript-eslint/eslint-plugin": "^8.41.0",
@@ -25,6 +28,8 @@
     "cross-env": "^10.0.0",
     "eslint": "^9.34.0",
     "jest": "^30.1.1",
+    "tailwindcss": "^4.3.3",
+    "ts-jest": "^29.4.1",
     "typescript": "^5.9.2",
     "vite": "^8.0.16",
     "vite-plugin-web-extension": "^4.5.0"

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -1,14 +1,7 @@
 import browser, { Menus } from 'webextension-polyfill';
 import { Client } from '@crypt.fyi/core';
-import { config } from './config';
-
-const manifest = chrome.runtime.getManifest();
-
-const client = new Client({
-  apiUrl: config.apiUrl,
-  keyLength: config.keyLength,
-  xClient: `@crypt.fyi/extension:${manifest.version}`,
-});
+import { KEY_LENGTH } from './config';
+import { resolveConfig, toCreateOptions } from './resolveConfig';
 
 const contextMenuId = '@crypt.fyi/encrypt-selection';
 
@@ -27,8 +20,26 @@ browser.contextMenus.create(
   },
 );
 
+// No default_popup — toolbar click opens the options page for discoverability.
+chrome.action.onClicked.addListener(() => {
+  void chrome.runtime.openOptionsPage();
+});
+
 function isScriptableUrl(url: string): boolean {
   return url.startsWith('http://') || url.startsWith('https://');
+}
+
+async function createClient() {
+  const { config } = await resolveConfig();
+  const manifest = chrome.runtime.getManifest();
+  return {
+    config,
+    client: new Client({
+      apiUrl: config.apiUrl,
+      keyLength: KEY_LENGTH,
+      xClient: `@crypt.fyi/extension:${manifest.version}`,
+    }),
+  };
 }
 
 browser.contextMenus.onClicked.addListener(async (info: Menus.OnClickData, tab) => {
@@ -42,13 +53,11 @@ browser.contextMenus.onClicked.addListener(async (info: Menus.OnClickData, tab) 
     return;
   }
 
-  // TODO: add an inline popover form w/ content script to capture relevant inputs
-
   try {
+    const { config, client } = await createClient();
     const result = await client.create({
       c: info.selectionText,
-      b: true,
-      ttl: config.defaultTtl,
+      ...toCreateOptions(config),
     });
     const url = `${config.webUrl}/${result.id}#${result.key}`;
 

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -30,7 +30,13 @@ function isScriptableUrl(url: string): boolean {
 }
 
 async function createClient() {
-  const { config } = await resolveConfig();
+  const resolved = await resolveConfig();
+  // Prefer a hard failure over silently posting ciphertext to the public API
+  // (or firing a webhook with no events) when org/user endpoint policy is bad.
+  if (resolved.createBlockingErrors.length > 0) {
+    throw new Error(resolved.createBlockingErrors.join('\n'));
+  }
+  const { config } = resolved;
   const manifest = chrome.runtime.getManifest();
   return {
     config,

--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -1,9 +1,83 @@
-export const config = {
-  apiUrl: (import.meta.env.VITE_API_URL as string | undefined) || 'https://api.crypt.fyi',
-  webUrl: (import.meta.env.VITE_WEB_URL as string | undefined) || 'https://crypt.fyi',
-  defaultTtl: getEnvNumber(import.meta.env.VITE_DEFAULT_TTL, 30 * 60 * 1000),
-  keyLength: getEnvNumber(import.meta.env.VITE_KEY_LENGTH, 32),
+/** Build-time fallbacks; runtime overrides come from storage (user > managed > build). */
+
+// Vite injects import.meta.env at build time; Node/Jest may not define `.env`.
+const env = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env ?? {};
+
+export const MINUTE = 1000 * 60;
+export const HOUR = MINUTE * 60;
+export const DAY = HOUR * 24;
+
+export const MAX_IP_RESTRICTIONS = 3;
+
+export const TTL_OPTIONS = [
+  { label: '5 minutes', value: 5 * MINUTE },
+  { label: '30 minutes', value: 30 * MINUTE },
+  { label: '1 hour', value: HOUR },
+  { label: '4 hours', value: 4 * HOUR },
+  { label: '12 hours', value: 12 * HOUR },
+  { label: '1 day', value: DAY },
+  { label: '3 days', value: 3 * DAY },
+  { label: '7 days', value: 7 * DAY },
+] as const;
+
+export const BUILD_DEFAULTS = {
+  apiUrl: env.VITE_API_URL || 'https://api.crypt.fyi',
+  webUrl: env.VITE_WEB_URL || 'https://crypt.fyi',
+  ttl: getEnvNumber(env.VITE_DEFAULT_TTL, 30 * MINUTE),
+  burn: true,
+  ips: undefined as string | undefined,
+  rc: undefined as number | undefined,
+  fc: undefined as number | undefined,
+  webhookUrl: undefined as string | undefined,
+  webhookName: undefined as string | undefined,
+  webhookOnRead: true,
+  webhookOnFailPassword: false,
+  webhookOnFailIp: false,
+  webhookOnBurn: false,
 } as const;
+
+/** Crypto key length stays build-time only — not a user/admin dial. */
+export const KEY_LENGTH = getEnvNumber(env.VITE_KEY_LENGTH, 32);
+
+export type ExtensionConfig = {
+  apiUrl: string;
+  webUrl: string;
+  ttl: number;
+  burn: boolean;
+  ips?: string;
+  rc?: number;
+  fc?: number;
+  webhookUrl?: string;
+  webhookName?: string;
+  webhookOnRead: boolean;
+  webhookOnFailPassword: boolean;
+  webhookOnFailIp: boolean;
+  webhookOnBurn: boolean;
+};
+
+/**
+ * Keys that can appear in storage.sync / storage.managed.
+ * `null` clears an optional so it does not fall back to a lower layer.
+ */
+export type ConfigOverride = {
+  [K in keyof ExtensionConfig]?: ExtensionConfig[K] | null;
+};
+
+export const CONFIG_KEYS = [
+  'apiUrl',
+  'webUrl',
+  'ttl',
+  'burn',
+  'ips',
+  'rc',
+  'fc',
+  'webhookUrl',
+  'webhookName',
+  'webhookOnRead',
+  'webhookOnFailPassword',
+  'webhookOnFailIp',
+  'webhookOnBurn',
+] as const satisfies ReadonlyArray<keyof ExtensionConfig>;
 
 function getEnvNumber(env: string | undefined, defaultValue: number): number {
   if (!env) {

--- a/packages/extension/src/config.ts
+++ b/packages/extension/src/config.ts
@@ -20,10 +20,25 @@ export const TTL_OPTIONS = [
   { label: '7 days', value: 7 * DAY },
 ] as const;
 
+/** Snap an arbitrary duration to the nearest supported TTL (keeps UI + schema in sync). */
+export function findClosestTtl(ttl: number): number {
+  let closest = TTL_OPTIONS[0].value;
+  let best = Math.abs(ttl - closest);
+  for (const option of TTL_OPTIONS) {
+    const distance = Math.abs(ttl - option.value);
+    if (distance < best) {
+      closest = option.value;
+      best = distance;
+    }
+  }
+  return closest;
+}
+
 export const BUILD_DEFAULTS = {
   apiUrl: env.VITE_API_URL || 'https://api.crypt.fyi',
   webUrl: env.VITE_WEB_URL || 'https://crypt.fyi',
-  ttl: getEnvNumber(env.VITE_DEFAULT_TTL, 30 * MINUTE),
+  // Env may set a non-listed duration; snap so options Save never invents a new TTL.
+  ttl: findClosestTtl(getEnvNumber(env.VITE_DEFAULT_TTL, 30 * MINUTE)),
   burn: true,
   ips: undefined as string | undefined,
   rc: undefined as number | undefined,

--- a/packages/extension/src/configMerge.test.ts
+++ b/packages/extension/src/configMerge.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from '@jest/globals';
+import { BUILD_DEFAULTS, type ExtensionConfig } from './config';
+import { parseConfigOverride } from './configSchema';
+import { mergeConfigLayers, toCreateOptions } from './configMerge';
+
+const build: ExtensionConfig = {
+  apiUrl: BUILD_DEFAULTS.apiUrl,
+  webUrl: BUILD_DEFAULTS.webUrl,
+  ttl: BUILD_DEFAULTS.ttl,
+  burn: BUILD_DEFAULTS.burn,
+  ips: BUILD_DEFAULTS.ips,
+  rc: BUILD_DEFAULTS.rc,
+  fc: BUILD_DEFAULTS.fc,
+  webhookUrl: BUILD_DEFAULTS.webhookUrl,
+  webhookName: BUILD_DEFAULTS.webhookName,
+  webhookOnRead: BUILD_DEFAULTS.webhookOnRead,
+  webhookOnFailPassword: BUILD_DEFAULTS.webhookOnFailPassword,
+  webhookOnFailIp: BUILD_DEFAULTS.webhookOnFailIp,
+  webhookOnBurn: BUILD_DEFAULTS.webhookOnBurn,
+};
+
+describe('mergeConfigLayers', () => {
+  it('prefers user over managed over build', () => {
+    const { config, sources } = mergeConfigLayers(
+      build,
+      { apiUrl: 'https://managed.example/api', ttl: 3600000 },
+      { apiUrl: 'https://user.example/api' },
+    );
+
+    expect(config.apiUrl).toBe('https://user.example/api');
+    expect(config.ttl).toBe(3600000);
+    expect(config.burn).toBe(true);
+    expect(sources.apiUrl).toBe('user');
+    expect(sources.ttl).toBe('managed');
+    expect(sources.burn).toBe('build');
+  });
+
+  it('lets user null clear a managed optional', () => {
+    const { config, sources } = mergeConfigLayers(build, { ips: '203.0.113.1' }, { ips: null });
+
+    expect(config.ips).toBeUndefined();
+    expect(sources.ips).toBe('user');
+  });
+
+  it('strips rc when burn is enabled', () => {
+    const { config } = mergeConfigLayers(build, {}, { burn: true, rc: 5 });
+    expect(config.burn).toBe(true);
+    expect(config.rc).toBeUndefined();
+  });
+});
+
+describe('parseConfigOverride', () => {
+  it('keeps valid keys when one key is invalid', () => {
+    const { data, errors } = parseConfigOverride({
+      apiUrl: 'https://ok.example',
+      ttl: 123,
+    });
+
+    expect(data.apiUrl).toBe('https://ok.example');
+    expect(data.ttl).toBeUndefined();
+    expect(errors.some((e) => e.startsWith('ttl:'))).toBe(true);
+  });
+
+  it('rejects burn + rc together', () => {
+    const { data, errors } = parseConfigOverride({ burn: true, rc: 3 });
+    expect(data.rc).toBeUndefined();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('toCreateOptions', () => {
+  it('omits webhook when url is unset', () => {
+    expect(toCreateOptions(build).wh).toBeUndefined();
+  });
+
+  it('maps webhook fields', () => {
+    const options = toCreateOptions({
+      ...build,
+      burn: false,
+      rc: 3,
+      webhookUrl: 'https://hooks.example/crypt',
+      webhookName: 'n',
+      webhookOnRead: true,
+      webhookOnFailPassword: true,
+      webhookOnFailIp: false,
+      webhookOnBurn: true,
+    });
+
+    expect(options).toEqual({
+      b: false,
+      ttl: build.ttl,
+      ips: undefined,
+      rc: 3,
+      fc: undefined,
+      wh: {
+        u: 'https://hooks.example/crypt',
+        n: 'n',
+        r: true,
+        fpk: true,
+        fip: false,
+        b: true,
+      },
+    });
+  });
+});

--- a/packages/extension/src/configMerge.test.ts
+++ b/packages/extension/src/configMerge.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from '@jest/globals';
-import { BUILD_DEFAULTS, type ExtensionConfig } from './config';
+import { BUILD_DEFAULTS, findClosestTtl, type ExtensionConfig } from './config';
 import { parseConfigOverride } from './configSchema';
-import { mergeConfigLayers, toCreateOptions } from './configMerge';
+import {
+  mergeConfigLayers,
+  toCreateOptions,
+  toExportOverride,
+  validateMergedConfig,
+} from './configMerge';
 
 const build: ExtensionConfig = {
   apiUrl: BUILD_DEFAULTS.apiUrl,
@@ -18,6 +23,16 @@ const build: ExtensionConfig = {
   webhookOnFailIp: BUILD_DEFAULTS.webhookOnFailIp,
   webhookOnBurn: BUILD_DEFAULTS.webhookOnBurn,
 };
+
+describe('findClosestTtl', () => {
+  it('returns an exact match unchanged', () => {
+    expect(findClosestTtl(30 * 60 * 1000)).toBe(30 * 60 * 1000);
+  });
+
+  it('snaps arbitrary durations to a supported option', () => {
+    expect(findClosestTtl(5 * 60 * 1000 + 1)).toBe(5 * 60 * 1000);
+  });
+});
 
 describe('mergeConfigLayers', () => {
   it('prefers user over managed over build', () => {
@@ -66,6 +81,18 @@ describe('parseConfigOverride', () => {
     expect(data.rc).toBeUndefined();
     expect(errors.length).toBeGreaterThan(0);
   });
+
+  it('rejects private apiUrl hosts', () => {
+    const { data, errors } = parseConfigOverride({ apiUrl: 'http://169.254.169.254' });
+    expect(data.apiUrl).toBeUndefined();
+    expect(errors.some((e) => e.startsWith('apiUrl:'))).toBe(true);
+  });
+
+  it('rejects localhost webUrl', () => {
+    const { data, errors } = parseConfigOverride({ webUrl: 'http://localhost:3000' });
+    expect(data.webUrl).toBeUndefined();
+    expect(errors.some((e) => e.startsWith('webUrl:'))).toBe(true);
+  });
 });
 
 describe('toCreateOptions', () => {
@@ -101,5 +128,38 @@ describe('toCreateOptions', () => {
         b: true,
       },
     });
+  });
+});
+
+describe('toExportOverride', () => {
+  it('encodes cleared optionals as null for round-trips', () => {
+    const exported = toExportOverride({ ...build, ips: undefined, webhookUrl: undefined });
+    expect(exported.ips).toBeNull();
+    expect(exported.webhookUrl).toBeNull();
+    expect(exported.apiUrl).toBe(build.apiUrl);
+  });
+});
+
+describe('validateMergedConfig', () => {
+  it('flags webhook URL with all events disabled across layers', () => {
+    const errors = validateMergedConfig({
+      ...build,
+      webhookUrl: 'https://hooks.example/crypt',
+      webhookOnRead: false,
+      webhookOnFailPassword: false,
+      webhookOnFailIp: false,
+      webhookOnBurn: false,
+    });
+    expect(errors.some((e) => e.startsWith('webhookUrl:'))).toBe(true);
+  });
+
+  it('allows webhook when at least one event is on', () => {
+    expect(
+      validateMergedConfig({
+        ...build,
+        webhookUrl: 'https://hooks.example/crypt',
+        webhookOnRead: true,
+      }),
+    ).toEqual([]);
   });
 });

--- a/packages/extension/src/configMerge.ts
+++ b/packages/extension/src/configMerge.ts
@@ -170,9 +170,7 @@ export function validateMergedConfig(config: ExtensionConfig): string[] {
       config.webhookOnBurn
     )
   ) {
-    errors.push(
-      'webhookUrl: At least one webhook event must be enabled when a webhook URL is set',
-    );
+    errors.push('webhookUrl: At least one webhook event must be enabled when a webhook URL is set');
   }
   return errors;
 }

--- a/packages/extension/src/configMerge.ts
+++ b/packages/extension/src/configMerge.ts
@@ -1,0 +1,135 @@
+import { BUILD_DEFAULTS, CONFIG_KEYS, type ConfigOverride, type ExtensionConfig } from './config';
+
+export type ConfigSource = 'user' | 'managed' | 'build';
+
+export type MergedConfig = {
+  config: ExtensionConfig;
+  /** Which layer supplied each key after merge. */
+  sources: Record<keyof ExtensionConfig, ConfigSource>;
+  managedKeys: Array<keyof ExtensionConfig>;
+  userKeys: Array<keyof ExtensionConfig>;
+};
+
+function emptyOptional(value: string | undefined | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function isPresent(obj: ConfigOverride, key: keyof ExtensionConfig): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function applyOverrideValue(
+  config: ExtensionConfig,
+  key: keyof ExtensionConfig,
+  value: unknown,
+): void {
+  // null / empty string = explicit clear (do not fall through to lower layers)
+  if (value === null || value === '') {
+    if (key === 'burn') {
+      config.burn = BUILD_DEFAULTS.burn;
+      return;
+    }
+    if (key === 'webhookOnRead') {
+      config.webhookOnRead = BUILD_DEFAULTS.webhookOnRead;
+      return;
+    }
+    if (key === 'webhookOnFailPassword') {
+      config.webhookOnFailPassword = BUILD_DEFAULTS.webhookOnFailPassword;
+      return;
+    }
+    if (key === 'webhookOnFailIp') {
+      config.webhookOnFailIp = BUILD_DEFAULTS.webhookOnFailIp;
+      return;
+    }
+    if (key === 'webhookOnBurn') {
+      config.webhookOnBurn = BUILD_DEFAULTS.webhookOnBurn;
+      return;
+    }
+    (config as Record<string, unknown>)[key] = undefined;
+    return;
+  }
+
+  (config as Record<string, unknown>)[key] = value;
+}
+
+export function buildDefaultsConfig(): ExtensionConfig {
+  return {
+    apiUrl: BUILD_DEFAULTS.apiUrl,
+    webUrl: BUILD_DEFAULTS.webUrl,
+    ttl: BUILD_DEFAULTS.ttl,
+    burn: BUILD_DEFAULTS.burn,
+    ips: BUILD_DEFAULTS.ips,
+    rc: BUILD_DEFAULTS.rc,
+    fc: BUILD_DEFAULTS.fc,
+    webhookUrl: BUILD_DEFAULTS.webhookUrl,
+    webhookName: BUILD_DEFAULTS.webhookName,
+    webhookOnRead: BUILD_DEFAULTS.webhookOnRead,
+    webhookOnFailPassword: BUILD_DEFAULTS.webhookOnFailPassword,
+    webhookOnFailIp: BUILD_DEFAULTS.webhookOnFailIp,
+    webhookOnBurn: BUILD_DEFAULTS.webhookOnBurn,
+  };
+}
+
+/**
+ * Seed semantics: user overrides win, then managed (admin seed), then build.
+ * Presence in a layer matters — including null/"" clears from the user layer.
+ */
+export function mergeConfigLayers(
+  build: ExtensionConfig,
+  managed: ConfigOverride,
+  user: ConfigOverride,
+): MergedConfig {
+  const sources = {} as Record<keyof ExtensionConfig, ConfigSource>;
+  const config = { ...build } as ExtensionConfig;
+  const managedKeys: Array<keyof ExtensionConfig> = [];
+  const userKeys: Array<keyof ExtensionConfig> = [];
+
+  for (const key of CONFIG_KEYS) {
+    if (isPresent(user, key)) {
+      applyOverrideValue(config, key, user[key]);
+      sources[key] = 'user';
+      userKeys.push(key);
+    } else if (isPresent(managed, key) && managed[key] !== null && managed[key] !== '') {
+      applyOverrideValue(config, key, managed[key]);
+      sources[key] = 'managed';
+      managedKeys.push(key);
+    } else {
+      sources[key] = 'build';
+    }
+  }
+
+  // Burn wins over read-count when both somehow survive validation
+  if (config.burn) {
+    config.rc = undefined;
+  }
+
+  config.ips = emptyOptional(config.ips);
+  config.webhookUrl = emptyOptional(config.webhookUrl);
+  config.webhookName = emptyOptional(config.webhookName);
+
+  return { config, sources, managedKeys, userKeys };
+}
+
+/** Build create() payload fields from resolved config (password intentionally omitted). */
+export function toCreateOptions(config: ExtensionConfig) {
+  const webhookUrl = emptyOptional(config.webhookUrl);
+
+  return {
+    b: config.burn,
+    ttl: config.ttl,
+    ips: emptyOptional(config.ips),
+    rc: config.burn ? undefined : config.rc,
+    fc: config.fc,
+    wh: webhookUrl
+      ? {
+          u: webhookUrl,
+          n: emptyOptional(config.webhookName),
+          r: config.webhookOnRead,
+          fpk: config.webhookOnFailPassword,
+          fip: config.webhookOnFailIp,
+          b: config.webhookOnBurn,
+        }
+      : undefined,
+  };
+}

--- a/packages/extension/src/configMerge.ts
+++ b/packages/extension/src/configMerge.ts
@@ -133,3 +133,46 @@ export function toCreateOptions(config: ExtensionConfig) {
       : undefined,
   };
 }
+
+/**
+ * Full user-layer snapshot suitable for export/import round-trips.
+ * Empty optionals are encoded as `null` so clears survive import (and do not
+ * fall back to managed/build again).
+ */
+export function toExportOverride(config: ExtensionConfig): ConfigOverride {
+  return {
+    apiUrl: config.apiUrl,
+    webUrl: config.webUrl,
+    ttl: config.ttl,
+    burn: config.burn,
+    ips: config.ips ?? null,
+    rc: config.rc ?? null,
+    fc: config.fc ?? null,
+    webhookUrl: config.webhookUrl ?? null,
+    webhookName: config.webhookName ?? null,
+    webhookOnRead: config.webhookOnRead,
+    webhookOnFailPassword: config.webhookOnFailPassword,
+    webhookOnFailIp: config.webhookOnFailIp,
+    webhookOnBurn: config.webhookOnBurn,
+  };
+}
+
+/** Cross-layer checks that per-field parse cannot see (managed URL + user event flags). */
+export function validateMergedConfig(config: ExtensionConfig): string[] {
+  const errors: string[] = [];
+  const webhookUrl = emptyOptional(config.webhookUrl);
+  if (
+    webhookUrl &&
+    !(
+      config.webhookOnRead ||
+      config.webhookOnFailPassword ||
+      config.webhookOnFailIp ||
+      config.webhookOnBurn
+    )
+  ) {
+    errors.push(
+      'webhookUrl: At least one webhook event must be enabled when a webhook URL is set',
+    );
+  }
+  return errors;
+}

--- a/packages/extension/src/configSchema.ts
+++ b/packages/extension/src/configSchema.ts
@@ -1,0 +1,176 @@
+import { z } from 'zod';
+import { isValidWebhookUrl } from '@crypt.fyi/core';
+import { CONFIG_KEYS, MAX_IP_RESTRICTIONS, TTL_OPTIONS } from './config';
+
+const ttlValues = TTL_OPTIONS.map((o) => o.value);
+
+const ipsSchema = z
+  .union([z.string(), z.null()])
+  .optional()
+  .superRefine((val, ctx) => {
+    if (val == null || !String(val).trim()) return;
+
+    const ips = String(val)
+      .split(',')
+      .map((ip) => ip.trim())
+      .filter(Boolean);
+
+    if (ips.length > MAX_IP_RESTRICTIONS) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `At most ${MAX_IP_RESTRICTIONS} IP/CIDR entries allowed`,
+      });
+      return;
+    }
+
+    for (const ip of ips) {
+      const isValidIP = z.union([z.ipv4(), z.ipv6()]).safeParse(ip).success;
+      const isValidCIDR = z.union([z.cidrv4(), z.cidrv6()]).safeParse(ip).success;
+      if (!isValidIP && !isValidCIDR) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Invalid IP or CIDR: ${ip}`,
+        });
+        return;
+      }
+    }
+  });
+
+const webhookUrlSchema = z
+  .union([z.string(), z.null()])
+  .optional()
+  .superRefine((val, ctx) => {
+    if (val == null || !String(val).trim()) return;
+    try {
+      if (!isValidWebhookUrl(String(val), { requireHttps: false })) {
+        ctx.addIssue({
+          code: 'custom',
+          message:
+            'Webhook URL must be a public http(s) URL and must not target a private or reserved address',
+        });
+      }
+    } catch {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Invalid webhook URL',
+      });
+    }
+  });
+
+const optionalNumber = z.union([z.number().int(), z.null()]).optional();
+
+/** Partial overrides from storage.managed / storage.sync / import JSON. */
+export const configOverrideSchema = z
+  .object({
+    apiUrl: z.string().url().optional(),
+    webUrl: z.string().url().optional(),
+    ttl: z
+      .number()
+      .refine((n) => (ttlValues as number[]).includes(n), {
+        message: 'TTL must be one of the supported durations',
+      })
+      .optional(),
+    burn: z.boolean().optional(),
+    ips: ipsSchema,
+    rc: optionalNumber.refine((n) => n == null || (n >= 2 && n <= 10), {
+      message: 'Read count must be between 2 and 10',
+    }),
+    fc: optionalNumber.refine((n) => n == null || (n >= 1 && n <= 10), {
+      message: 'Failure count must be between 1 and 10',
+    }),
+    webhookUrl: webhookUrlSchema,
+    webhookName: z.union([z.string().max(50), z.null()]).optional(),
+    webhookOnRead: z.boolean().optional(),
+    webhookOnFailPassword: z.boolean().optional(),
+    webhookOnFailIp: z.boolean().optional(),
+    webhookOnBurn: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    if (data.burn === true && data.rc != null) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['rc'],
+        message: 'Read count cannot be set when burn-after-reading is enabled',
+      });
+    }
+
+    const webhookUrl = data.webhookUrl == null ? '' : String(data.webhookUrl).trim();
+    if (webhookUrl) {
+      const onRead = data.webhookOnRead ?? true;
+      const onFailPassword = data.webhookOnFailPassword ?? false;
+      const onFailIp = data.webhookOnFailIp ?? false;
+      const onBurn = data.webhookOnBurn ?? false;
+      if (!(onRead || onFailPassword || onFailIp || onBurn)) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['webhookUrl'],
+          message: 'At least one webhook event must be enabled when a webhook URL is set',
+        });
+      }
+    }
+  });
+
+export type ParsedConfigOverride = z.infer<typeof configOverrideSchema>;
+
+const CONFIG_KEY_SET = new Set<string>(CONFIG_KEYS);
+
+/**
+ * Parse unknown storage/policy input. Invalid keys are dropped per-field so a
+ * bad managed value does not wipe the whole config.
+ *
+ * `null` (and empty string for string fields) means the user explicitly cleared
+ * a seeded value so it does not fall back to managed/build.
+ */
+export function parseConfigOverride(input: unknown): {
+  data: ParsedConfigOverride;
+  errors: string[];
+} {
+  if (input == null || typeof input !== 'object') {
+    return { data: {}, errors: [] };
+  }
+
+  const errors: string[] = [];
+  const raw = input as Record<string, unknown>;
+  const picked: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(raw)) {
+    if (!CONFIG_KEY_SET.has(key)) {
+      continue;
+    }
+    if (value === undefined) {
+      continue;
+    }
+    picked[key] = value;
+  }
+
+  const result = configOverrideSchema.safeParse(picked);
+  if (result.success) {
+    return { data: result.data, errors: [] };
+  }
+
+  const data: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(picked)) {
+    const single = configOverrideSchema.safeParse({ [key]: value });
+    if (single.success && key in single.data) {
+      data[key] = (single.data as Record<string, unknown>)[key];
+    } else {
+      const issue = result.error.issues.find((i) => i.path[0] === key);
+      errors.push(`${key}: ${issue?.message ?? 'invalid value'}`);
+    }
+  }
+
+  const cross = configOverrideSchema.safeParse(data);
+  if (!cross.success) {
+    for (const issue of cross.error.issues) {
+      const key = String(issue.path[0] ?? 'config');
+      errors.push(`${key}: ${issue.message}`);
+      if (issue.path[0] != null) {
+        delete data[String(issue.path[0])];
+      }
+    }
+    return { data: data as ParsedConfigOverride, errors };
+  }
+
+  return { data: cross.data, errors };
+}

--- a/packages/extension/src/configSchema.ts
+++ b/packages/extension/src/configSchema.ts
@@ -36,25 +36,30 @@ const ipsSchema = z
     }
   });
 
-const webhookUrlSchema = z
-  .union([z.string(), z.null()])
-  .optional()
-  .superRefine((val, ctx) => {
-    if (val == null || !String(val).trim()) return;
+function publicHttpUrlRefine(label: string) {
+  return (val: string, ctx: z.RefinementCtx) => {
     try {
-      if (!isValidWebhookUrl(String(val), { requireHttps: false })) {
+      if (!isValidWebhookUrl(val, { requireHttps: false })) {
         ctx.addIssue({
           code: 'custom',
-          message:
-            'Webhook URL must be a public http(s) URL and must not target a private or reserved address',
+          message: `${label} must be a public http(s) URL and must not target a private or reserved address`,
         });
       }
     } catch {
       ctx.addIssue({
         code: 'custom',
-        message: 'Invalid webhook URL',
+        message: `Invalid ${label}`,
       });
     }
+  };
+}
+
+const webhookUrlSchema = z
+  .union([z.string(), z.null()])
+  .optional()
+  .superRefine((val, ctx) => {
+    if (val == null || !String(val).trim()) return;
+    publicHttpUrlRefine('Webhook URL')(String(val), ctx);
   });
 
 const optionalNumber = z.union([z.number().int(), z.null()]).optional();
@@ -62,8 +67,9 @@ const optionalNumber = z.union([z.number().int(), z.null()]).optional();
 /** Partial overrides from storage.managed / storage.sync / import JSON. */
 export const configOverrideSchema = z
   .object({
-    apiUrl: z.string().url().optional(),
-    webUrl: z.string().url().optional(),
+    // Same public-host rules as webhooks — blocks literal private/metadata targets.
+    apiUrl: z.string().superRefine(publicHttpUrlRefine('API URL')).optional(),
+    webUrl: z.string().superRefine(publicHttpUrlRefine('Web URL')).optional(),
     ttl: z
       .number()
       .refine((n) => (ttlValues as number[]).includes(n), {

--- a/packages/extension/src/options/index.html
+++ b/packages/extension/src/options/index.html
@@ -174,11 +174,17 @@
           </button>
           <label
             class="file-btn inline-flex cursor-pointer items-center rounded-md border border-line bg-paper-elevated px-4 py-2.5 text-sm font-medium text-ink transition hover:bg-muted"
+            title="Replaces all saved overrides with the file contents. Omitted keys fall back to organization/built-in defaults."
           >
-            Import JSON
+            Import JSON (replace)
             <input id="import-input" type="file" accept="application/json,.json" class="sr-only" />
           </label>
         </div>
+        <p class="text-xs leading-relaxed text-ink-muted">
+          Import replaces your saved overrides entirely (same as Save). Use Export to capture the
+          current effective settings, including cleared optional fields as
+          <code class="text-[0.7rem]">null</code>.
+        </p>
       </form>
     </main>
     <script type="module" src="./main.ts"></script>

--- a/packages/extension/src/options/index.html
+++ b/packages/extension/src/options/index.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>crypt.fyi settings</title>
+  </head>
+  <body>
+    <main class="mx-auto max-w-xl px-5 py-10 sm:py-14">
+      <header class="mb-8">
+        <p class="text-sm font-semibold tracking-wide text-ink-muted">Browser extension</p>
+        <h1 class="mt-1 text-3xl font-semibold tracking-tight text-ink sm:text-4xl">crypt.fyi</h1>
+        <p class="mt-3 max-w-prose text-[0.95rem] leading-relaxed text-ink-muted">
+          Defaults used when you encrypt text from the context menu.
+        </p>
+        <p
+          id="status"
+          class="mt-4 hidden rounded-md border border-line bg-ok-soft px-3 py-2.5 text-sm text-ink"
+          role="status"
+        ></p>
+        <p
+          id="errors"
+          class="mt-4 hidden whitespace-pre-wrap rounded-md border border-danger/30 bg-danger-soft px-3 py-2.5 text-sm text-danger"
+          role="alert"
+        ></p>
+      </header>
+
+      <form id="settings-form" class="space-y-8" novalidate>
+        <section class="space-y-4 border-t border-line pt-6">
+          <h2 class="text-sm font-semibold uppercase tracking-[0.08em] text-ink-muted">
+            Endpoints
+          </h2>
+          <label class="block space-y-1.5">
+            <span class="text-sm font-semibold text-ink">API URL</span>
+            <input id="apiUrl" name="apiUrl" type="url" autocomplete="off" required />
+          </label>
+          <label class="block space-y-1.5">
+            <span class="text-sm font-semibold text-ink">Web URL</span>
+            <input id="webUrl" name="webUrl" type="url" autocomplete="off" required />
+          </label>
+        </section>
+
+        <section class="space-y-4 border-t border-line pt-6">
+          <h2 class="text-sm font-semibold uppercase tracking-[0.08em] text-ink-muted">
+            Secret defaults
+          </h2>
+          <label class="block space-y-1.5">
+            <span class="text-sm font-semibold text-ink">Time to live</span>
+            <!-- Options are also filled in HTML so the dropdown works even if JS is slow to hydrate -->
+            <select id="ttl" name="ttl">
+              <option value="300000">5 minutes</option>
+              <option value="1800000">30 minutes</option>
+              <option value="3600000">1 hour</option>
+              <option value="14400000">4 hours</option>
+              <option value="43200000">12 hours</option>
+              <option value="86400000">1 day</option>
+              <option value="259200000">3 days</option>
+              <option value="604800000">7 days</option>
+            </select>
+          </label>
+          <label class="flex items-start gap-3 rounded-md border border-line bg-muted px-3 py-3">
+            <input id="burn" name="burn" type="checkbox" class="mt-1 size-4 accent-primary" />
+            <span class="text-sm leading-snug text-ink">
+              <span class="font-semibold">Burn after reading</span>
+              <span class="mt-0.5 block text-ink-muted"
+                >Delete the secret after the first successful read.</span
+              >
+            </span>
+          </label>
+          <label class="block space-y-1.5">
+            <span class="text-sm font-semibold text-ink">IP / CIDR allow-list</span>
+            <input
+              id="ips"
+              name="ips"
+              type="text"
+              placeholder="203.0.113.1, 198.51.100.0/24"
+              autocomplete="off"
+            />
+            <span class="text-xs text-ink-muted">Comma-separated, max 3 entries</span>
+          </label>
+          <div class="grid gap-4 sm:grid-cols-2">
+            <label class="block space-y-1.5">
+              <span class="text-sm font-semibold text-ink">Read count</span>
+              <input id="rc" name="rc" type="number" min="2" max="10" step="1" />
+              <span class="text-xs text-ink-muted">2–10. Off when burn is enabled.</span>
+            </label>
+            <label class="block space-y-1.5">
+              <span class="text-sm font-semibold text-ink">Failure count</span>
+              <input id="fc" name="fc" type="number" min="1" max="10" step="1" />
+              <span class="text-xs text-ink-muted">Burn after N failed attempts</span>
+            </label>
+          </div>
+        </section>
+
+        <section class="space-y-4 border-t border-line pt-6">
+          <h2 class="text-sm font-semibold uppercase tracking-[0.08em] text-ink-muted">Webhook</h2>
+          <label class="block space-y-1.5">
+            <span class="text-sm font-semibold text-ink">URL</span>
+            <input
+              id="webhookUrl"
+              name="webhookUrl"
+              type="url"
+              placeholder="https://example.com/hooks/crypt"
+              autocomplete="off"
+            />
+          </label>
+          <label class="block space-y-1.5">
+            <span class="text-sm font-semibold text-ink">Name</span>
+            <input id="webhookName" name="webhookName" type="text" maxlength="50" />
+          </label>
+          <fieldset class="space-y-2 rounded-md border border-line bg-muted p-3">
+            <legend class="px-1 text-xs font-semibold uppercase tracking-[0.08em] text-ink-muted">
+              Events
+            </legend>
+            <label class="flex items-center gap-2.5 text-sm text-ink">
+              <input
+                id="webhookOnRead"
+                name="webhookOnRead"
+                type="checkbox"
+                class="size-4 accent-primary"
+              />
+              <span>On read</span>
+            </label>
+            <label class="flex items-center gap-2.5 text-sm text-ink">
+              <input
+                id="webhookOnFailPassword"
+                name="webhookOnFailPassword"
+                type="checkbox"
+                class="size-4 accent-primary"
+              />
+              <span>On password/key failure</span>
+            </label>
+            <label class="flex items-center gap-2.5 text-sm text-ink">
+              <input
+                id="webhookOnFailIp"
+                name="webhookOnFailIp"
+                type="checkbox"
+                class="size-4 accent-primary"
+              />
+              <span>On IP failure</span>
+            </label>
+            <label class="flex items-center gap-2.5 text-sm text-ink">
+              <input
+                id="webhookOnBurn"
+                name="webhookOnBurn"
+                type="checkbox"
+                class="size-4 accent-primary"
+              />
+              <span>On burn</span>
+            </label>
+          </fieldset>
+        </section>
+
+        <div class="flex flex-wrap gap-2 border-t border-line pt-6">
+          <button
+            type="submit"
+            class="rounded-md bg-primary px-4 py-2.5 text-sm font-semibold text-primary-fg shadow-sm transition hover:opacity-90"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            id="reset-btn"
+            class="rounded-md border border-line bg-paper-elevated px-4 py-2.5 text-sm font-medium text-ink transition hover:bg-muted"
+          >
+            Reset to defaults
+          </button>
+          <button
+            type="button"
+            id="export-btn"
+            class="rounded-md border border-line bg-paper-elevated px-4 py-2.5 text-sm font-medium text-ink transition hover:bg-muted"
+          >
+            Export JSON
+          </button>
+          <label
+            class="file-btn inline-flex cursor-pointer items-center rounded-md border border-line bg-paper-elevated px-4 py-2.5 text-sm font-medium text-ink transition hover:bg-muted"
+          >
+            Import JSON
+            <input id="import-input" type="file" accept="application/json,.json" class="sr-only" />
+          </label>
+        </div>
+      </form>
+    </main>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/extension/src/options/main.ts
+++ b/packages/extension/src/options/main.ts
@@ -1,0 +1,202 @@
+import './styles.css';
+import { TTL_OPTIONS, type ConfigOverride, type ExtensionConfig } from '../config';
+import { parseConfigOverride } from '../configSchema';
+import { clearUserConfig, resolveConfig, saveUserConfig } from '../resolveConfig';
+
+const form = document.getElementById('settings-form') as HTMLFormElement;
+const statusEl = document.getElementById('status') as HTMLParagraphElement;
+const errorsEl = document.getElementById('errors') as HTMLParagraphElement;
+const ttlSelect = document.getElementById('ttl') as HTMLSelectElement;
+const burnInput = document.getElementById('burn') as HTMLInputElement;
+const rcInput = document.getElementById('rc') as HTMLInputElement;
+const resetBtn = document.getElementById('reset-btn') as HTMLButtonElement;
+const exportBtn = document.getElementById('export-btn') as HTMLButtonElement;
+const importInput = document.getElementById('import-input') as HTMLInputElement;
+
+function setStatus(message: string | null) {
+  if (!message) {
+    statusEl.classList.add('hidden');
+    statusEl.textContent = '';
+    return;
+  }
+  statusEl.classList.remove('hidden');
+  statusEl.textContent = message;
+}
+
+function setErrors(messages: string[]) {
+  if (messages.length === 0) {
+    errorsEl.classList.add('hidden');
+    errorsEl.textContent = '';
+    return;
+  }
+  errorsEl.classList.remove('hidden');
+  errorsEl.textContent = messages.join('\n');
+}
+
+/** Ensure the select always has the supported TTL choices (HTML may already include them). */
+function fillTtlOptions() {
+  const existing = new Set(Array.from(ttlSelect.options).map((option) => option.value));
+
+  for (const option of TTL_OPTIONS) {
+    const value = String(option.value);
+    if (existing.has(value)) continue;
+    const el = document.createElement('option');
+    el.value = value;
+    el.textContent = option.label;
+    ttlSelect.append(el);
+  }
+}
+
+function findClosestTtl(ttl: number): number {
+  let closest = TTL_OPTIONS[0].value;
+  let best = Math.abs(ttl - closest);
+  for (const option of TTL_OPTIONS) {
+    const distance = Math.abs(ttl - option.value);
+    if (distance < best) {
+      closest = option.value;
+      best = distance;
+    }
+  }
+  return closest;
+}
+
+function syncBurnUi() {
+  const burned = burnInput.checked;
+  rcInput.disabled = burned;
+  if (burned) {
+    rcInput.value = '';
+  }
+}
+
+function applyConfigToForm(config: ExtensionConfig) {
+  (document.getElementById('apiUrl') as HTMLInputElement).value = config.apiUrl;
+  (document.getElementById('webUrl') as HTMLInputElement).value = config.webUrl;
+  // Setting a value that is not in <option>s blanks the select — snap to closest.
+  ttlSelect.value = String(findClosestTtl(config.ttl));
+  burnInput.checked = config.burn;
+  (document.getElementById('ips') as HTMLInputElement).value = config.ips ?? '';
+  rcInput.value = config.rc != null ? String(config.rc) : '';
+  (document.getElementById('fc') as HTMLInputElement).value =
+    config.fc != null ? String(config.fc) : '';
+  (document.getElementById('webhookUrl') as HTMLInputElement).value = config.webhookUrl ?? '';
+  (document.getElementById('webhookName') as HTMLInputElement).value = config.webhookName ?? '';
+  (document.getElementById('webhookOnRead') as HTMLInputElement).checked = config.webhookOnRead;
+  (document.getElementById('webhookOnFailPassword') as HTMLInputElement).checked =
+    config.webhookOnFailPassword;
+  (document.getElementById('webhookOnFailIp') as HTMLInputElement).checked = config.webhookOnFailIp;
+  (document.getElementById('webhookOnBurn') as HTMLInputElement).checked = config.webhookOnBurn;
+  syncBurnUi();
+}
+
+function readFormOverride(): ConfigOverride {
+  const ips = (document.getElementById('ips') as HTMLInputElement).value.trim();
+  const rcRaw = rcInput.value.trim();
+  const fcRaw = (document.getElementById('fc') as HTMLInputElement).value.trim();
+  const webhookUrl = (document.getElementById('webhookUrl') as HTMLInputElement).value.trim();
+  const webhookName = (document.getElementById('webhookName') as HTMLInputElement).value.trim();
+  const burn = burnInput.checked;
+
+  // Persist empties as null so users can clear organization-seeded optionals.
+  return {
+    apiUrl: (document.getElementById('apiUrl') as HTMLInputElement).value.trim(),
+    webUrl: (document.getElementById('webUrl') as HTMLInputElement).value.trim(),
+    ttl: Number(ttlSelect.value),
+    burn,
+    ips: ips || null,
+    rc: burn ? null : rcRaw ? Number(rcRaw) : null,
+    fc: fcRaw ? Number(fcRaw) : null,
+    webhookUrl: webhookUrl || null,
+    webhookName: webhookName || null,
+    webhookOnRead: (document.getElementById('webhookOnRead') as HTMLInputElement).checked,
+    webhookOnFailPassword: (document.getElementById('webhookOnFailPassword') as HTMLInputElement)
+      .checked,
+    webhookOnFailIp: (document.getElementById('webhookOnFailIp') as HTMLInputElement).checked,
+    webhookOnBurn: (document.getElementById('webhookOnBurn') as HTMLInputElement).checked,
+  };
+}
+
+async function refresh() {
+  const resolved = await resolveConfig();
+  applyConfigToForm(resolved.config);
+  setErrors(resolved.parseErrors);
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const override = readFormOverride();
+  const { data, errors } = parseConfigOverride(override);
+  if (errors.length > 0) {
+    setErrors(errors);
+    setStatus(null);
+    return;
+  }
+
+  const saveErrors = await saveUserConfig(data);
+  if (saveErrors.length > 0) {
+    setErrors(saveErrors);
+    return;
+  }
+
+  await refresh();
+  setStatus('Settings saved.');
+});
+
+burnInput.addEventListener('change', syncBurnUi);
+
+resetBtn.addEventListener('click', async () => {
+  await clearUserConfig();
+  await refresh();
+  setStatus('Settings reset to defaults.');
+});
+
+exportBtn.addEventListener('click', async () => {
+  const resolved = await resolveConfig();
+  const payload = {
+    apiUrl: resolved.config.apiUrl,
+    webUrl: resolved.config.webUrl,
+    ttl: resolved.config.ttl,
+    burn: resolved.config.burn,
+    ...(resolved.config.ips ? { ips: resolved.config.ips } : {}),
+    ...(resolved.config.rc != null ? { rc: resolved.config.rc } : {}),
+    ...(resolved.config.fc != null ? { fc: resolved.config.fc } : {}),
+    ...(resolved.config.webhookUrl ? { webhookUrl: resolved.config.webhookUrl } : {}),
+    ...(resolved.config.webhookName ? { webhookName: resolved.config.webhookName } : {}),
+    webhookOnRead: resolved.config.webhookOnRead,
+    webhookOnFailPassword: resolved.config.webhookOnFailPassword,
+    webhookOnFailIp: resolved.config.webhookOnFailIp,
+    webhookOnBurn: resolved.config.webhookOnBurn,
+  };
+
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'crypt-fyi-extension-config.json';
+  a.click();
+  URL.revokeObjectURL(url);
+});
+
+importInput.addEventListener('change', async () => {
+  const file = importInput.files?.[0];
+  importInput.value = '';
+  if (!file) return;
+
+  try {
+    const text = await file.text();
+    const json: unknown = JSON.parse(text);
+    const { data, errors } = parseConfigOverride(json);
+    if (Object.keys(data).length === 0) {
+      setErrors(errors.length > 0 ? errors : ['Import file contained no valid settings']);
+      return;
+    }
+    const saveErrors = await saveUserConfig(data);
+    await refresh();
+    setErrors([...errors, ...saveErrors]);
+    setStatus('Settings imported.');
+  } catch (error) {
+    setErrors([error instanceof Error ? error.message : 'Failed to import JSON']);
+  }
+});
+
+fillTtlOptions();
+void refresh();

--- a/packages/extension/src/options/main.ts
+++ b/packages/extension/src/options/main.ts
@@ -1,6 +1,7 @@
 import './styles.css';
-import { TTL_OPTIONS, type ConfigOverride, type ExtensionConfig } from '../config';
+import { findClosestTtl, TTL_OPTIONS, type ConfigOverride, type ExtensionConfig } from '../config';
 import { parseConfigOverride } from '../configSchema';
+import { toExportOverride } from '../configMerge';
 import { clearUserConfig, resolveConfig, saveUserConfig } from '../resolveConfig';
 
 const form = document.getElementById('settings-form') as HTMLFormElement;
@@ -45,19 +46,6 @@ function fillTtlOptions() {
     el.textContent = option.label;
     ttlSelect.append(el);
   }
-}
-
-function findClosestTtl(ttl: number): number {
-  let closest = TTL_OPTIONS[0].value;
-  let best = Math.abs(ttl - closest);
-  for (const option of TTL_OPTIONS) {
-    const distance = Math.abs(ttl - option.value);
-    if (distance < best) {
-      closest = option.value;
-      best = distance;
-    }
-  }
-  return closest;
 }
 
 function syncBurnUi() {
@@ -151,21 +139,8 @@ resetBtn.addEventListener('click', async () => {
 
 exportBtn.addEventListener('click', async () => {
   const resolved = await resolveConfig();
-  const payload = {
-    apiUrl: resolved.config.apiUrl,
-    webUrl: resolved.config.webUrl,
-    ttl: resolved.config.ttl,
-    burn: resolved.config.burn,
-    ...(resolved.config.ips ? { ips: resolved.config.ips } : {}),
-    ...(resolved.config.rc != null ? { rc: resolved.config.rc } : {}),
-    ...(resolved.config.fc != null ? { fc: resolved.config.fc } : {}),
-    ...(resolved.config.webhookUrl ? { webhookUrl: resolved.config.webhookUrl } : {}),
-    ...(resolved.config.webhookName ? { webhookName: resolved.config.webhookName } : {}),
-    webhookOnRead: resolved.config.webhookOnRead,
-    webhookOnFailPassword: resolved.config.webhookOnFailPassword,
-    webhookOnFailIp: resolved.config.webhookOnFailIp,
-    webhookOnBurn: resolved.config.webhookOnBurn,
-  };
+  // Include nulls for empty optionals so export → import preserves clears.
+  const payload = toExportOverride(resolved.config);
 
   const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
@@ -189,10 +164,11 @@ importInput.addEventListener('change', async () => {
       setErrors(errors.length > 0 ? errors : ['Import file contained no valid settings']);
       return;
     }
+    // Replace-all: omitted keys fall back to managed/build (same as Save).
     const saveErrors = await saveUserConfig(data);
     await refresh();
     setErrors([...errors, ...saveErrors]);
-    setStatus('Settings imported.');
+    setStatus('Settings imported (replaced all saved overrides).');
   } catch (error) {
     setErrors([error instanceof Error ? error.message : 'Failed to import JSON']);
   }

--- a/packages/extension/src/options/styles.css
+++ b/packages/extension/src/options/styles.css
@@ -1,0 +1,62 @@
+@import 'tailwindcss';
+
+/* Match packages/web design tokens (neutral black/white brand). */
+@theme {
+  --font-sans: 'Segoe UI', 'Helvetica Neue', ui-sans-serif, sans-serif;
+  --color-ink: hsl(0 0% 5%);
+  --color-ink-muted: hsl(0 0% 47%);
+  --color-paper: hsl(0 0% 100%);
+  --color-paper-elevated: hsl(0 0% 100%);
+  --color-line: hsl(0 0% 91%);
+  --color-primary: hsl(0 0% 11%);
+  --color-primary-fg: hsl(0 0% 98%);
+  --color-muted: hsl(0 0% 96%);
+  --color-danger: hsl(0 84% 40%);
+  --color-danger-soft: hsl(0 84% 96%);
+  --color-ok-soft: hsl(0 0% 96%);
+}
+
+@media (prefers-color-scheme: dark) {
+  @theme {
+    --color-ink: hsl(0 0% 98%);
+    --color-ink-muted: hsl(0 0% 65%);
+    --color-paper: hsl(0 0% 5%);
+    --color-paper-elevated: hsl(0 0% 5%);
+    --color-line: hsl(0 0% 25%);
+    --color-primary: hsl(0 0% 98%);
+    --color-primary-fg: hsl(0 0% 11%);
+    --color-muted: hsl(0 0% 17%);
+    --color-danger: hsl(0 65% 68%);
+    --color-danger-soft: hsl(0 40% 16%);
+    --color-ok-soft: hsl(0 0% 17%);
+  }
+}
+
+@layer base {
+  html {
+    color-scheme: light dark;
+  }
+
+  body {
+    @apply m-0 min-h-screen bg-paper font-sans text-ink antialiased;
+  }
+
+  input[type='url'],
+  input[type='text'],
+  input[type='number'],
+  select {
+    @apply w-full rounded-md border border-line bg-paper-elevated px-3 py-2.5 text-ink shadow-sm outline-none transition;
+  }
+
+  input:focus,
+  select:focus,
+  button:focus-visible,
+  .file-btn:focus-within {
+    @apply ring-2 ring-primary/25 ring-offset-2 ring-offset-paper;
+  }
+
+  input:disabled,
+  select:disabled {
+    @apply cursor-not-allowed opacity-50;
+  }
+}

--- a/packages/extension/src/resolveConfig.ts
+++ b/packages/extension/src/resolveConfig.ts
@@ -1,0 +1,65 @@
+import browser from 'webextension-polyfill';
+import type { ConfigOverride, ExtensionConfig } from './config';
+import { parseConfigOverride } from './configSchema';
+import {
+  buildDefaultsConfig,
+  mergeConfigLayers,
+  toCreateOptions,
+  type ConfigSource,
+  type MergedConfig,
+} from './configMerge';
+
+export type { ConfigSource };
+export { toCreateOptions, mergeConfigLayers, buildDefaultsConfig };
+
+export type ResolvedConfig = MergedConfig & {
+  parseErrors: string[];
+};
+
+async function readStorageArea(
+  area: 'sync' | 'managed',
+): Promise<{ data: ConfigOverride; errors: string[] }> {
+  try {
+    const raw = await browser.storage[area].get(null);
+    return parseConfigOverride(raw);
+  } catch (error) {
+    // Firefox throws when managed storage is unset; Chrome returns {}.
+    if (area === 'managed') {
+      return { data: {}, errors: [] };
+    }
+    console.warn(`[crypt.fyi] Failed to read storage.${area}:`, error);
+    return { data: {}, errors: [`storage.${area}: ${String(error)}`] };
+  }
+}
+
+export async function resolveConfig(): Promise<ResolvedConfig> {
+  const [managedResult, userResult] = await Promise.all([
+    readStorageArea('managed'),
+    readStorageArea('sync'),
+  ]);
+
+  const merged = mergeConfigLayers(buildDefaultsConfig(), managedResult.data, userResult.data);
+
+  return {
+    ...merged,
+    parseErrors: [...managedResult.errors, ...userResult.errors],
+  };
+}
+
+export async function saveUserConfig(override: ConfigOverride): Promise<string[]> {
+  const { data, errors } = parseConfigOverride(override);
+  if (errors.length > 0 && Object.keys(data).length === 0) {
+    return errors;
+  }
+
+  // Replace user layer entirely so omitted keys fall back to managed/build
+  await browser.storage.sync.clear();
+  await browser.storage.sync.set(data);
+  return errors;
+}
+
+export async function clearUserConfig(): Promise<void> {
+  await browser.storage.sync.clear();
+}
+
+export type { ExtensionConfig };

--- a/packages/extension/src/resolveConfig.ts
+++ b/packages/extension/src/resolveConfig.ts
@@ -5,16 +5,25 @@ import {
   buildDefaultsConfig,
   mergeConfigLayers,
   toCreateOptions,
+  toExportOverride,
+  validateMergedConfig,
   type ConfigSource,
   type MergedConfig,
 } from './configMerge';
 
 export type { ConfigSource };
-export { toCreateOptions, mergeConfigLayers, buildDefaultsConfig };
+export { toCreateOptions, toExportOverride, mergeConfigLayers, buildDefaultsConfig };
 
 export type ResolvedConfig = MergedConfig & {
   parseErrors: string[];
+  /**
+   * Errors that must block encryption (invalid endpoints that silently fell
+   * back to build defaults, or cross-layer webhook violations).
+   */
+  createBlockingErrors: string[];
 };
+
+const ENDPOINT_KEYS = ['apiUrl', 'webUrl'] as const;
 
 async function readStorageArea(
   area: 'sync' | 'managed',
@@ -32,6 +41,35 @@ async function readStorageArea(
   }
 }
 
+function errorsForKey(errors: string[], key: string): string[] {
+  return errors.filter((error) => error.startsWith(`${key}:`));
+}
+
+/**
+ * If a layer supplied an invalid endpoint and nothing higher replaced it, merge
+ * would fall through to the public build default — fail closed instead.
+ */
+function collectEndpointFailOpenErrors(
+  sources: MergedConfig['sources'],
+  managedErrors: string[],
+  userErrors: string[],
+): string[] {
+  const blocked: string[] = [];
+  for (const key of ENDPOINT_KEYS) {
+    if (sources[key] !== 'build') continue;
+    const fromUser = errorsForKey(userErrors, key);
+    const fromManaged = errorsForKey(managedErrors, key);
+    if (fromUser.length > 0 || fromManaged.length > 0) {
+      blocked.push(
+        ...fromUser,
+        ...fromManaged,
+        `${key}: refusing to fall back to the built-in default after an invalid configured value`,
+      );
+    }
+  }
+  return blocked;
+}
+
 export async function resolveConfig(): Promise<ResolvedConfig> {
   const [managedResult, userResult] = await Promise.all([
     readStorageArea('managed'),
@@ -39,10 +77,17 @@ export async function resolveConfig(): Promise<ResolvedConfig> {
   ]);
 
   const merged = mergeConfigLayers(buildDefaultsConfig(), managedResult.data, userResult.data);
+  const mergeErrors = validateMergedConfig(merged.config);
+  const parseErrors = [...managedResult.errors, ...userResult.errors, ...mergeErrors];
+  const createBlockingErrors = [
+    ...collectEndpointFailOpenErrors(merged.sources, managedResult.errors, userResult.errors),
+    ...mergeErrors,
+  ];
 
   return {
     ...merged,
-    parseErrors: [...managedResult.errors, ...userResult.errors],
+    parseErrors,
+    createBlockingErrors,
   };
 }
 

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -1,16 +1,38 @@
 import { defineConfig } from 'vite';
 import webExtension from 'vite-plugin-web-extension';
+import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
 import fs from 'fs';
 
 const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const managedSchema = fs.readFileSync('managed_schema.json', 'utf8');
 
 export default defineConfig({
+  // Relative asset URLs so options HTML under src/options/ resolves JS/CSS in the extension.
+  base: './',
   publicDir: 'icons',
   server: {
     port: 5174,
   },
   plugins: [
+    tailwindcss(),
+    {
+      name: 'emit-managed-schema',
+      generateBundle() {
+        this.emitFile({
+          type: 'asset',
+          fileName: 'managed_schema.json',
+          source: managedSchema,
+        });
+      },
+    },
+    {
+      // chrome-extension:// pages can fail to load module scripts with crossorigin set
+      name: 'strip-html-crossorigin',
+      transformIndexHtml(html) {
+        return html.replace(/ crossorigin/g, '');
+      },
+    },
     webExtension({
       disableAutoLaunch: true,
       manifest: () => ({
@@ -18,10 +40,33 @@ export default defineConfig({
         name: 'crypt.fyi',
         version: pkg.version,
         description: 'Securely share encrypted text via crypt.fyi',
-        permissions: ['contextMenus', 'clipboardWrite', 'activeTab', 'scripting', 'notifications'],
+        permissions: [
+          'contextMenus',
+          'clipboardWrite',
+          'activeTab',
+          'scripting',
+          'notifications',
+          'storage',
+        ],
         background: {
           service_worker: 'src/background.ts',
           type: 'module',
+        },
+        action: {
+          default_title: 'crypt.fyi settings',
+          default_icon: {
+            '16': '16.png',
+            '32': '32.png',
+            '48': '48.png',
+            '128': '128.png',
+          },
+        },
+        options_ui: {
+          page: 'src/options/index.html',
+          open_in_tab: true,
+        },
+        storage: {
+          managed_schema: 'managed_schema.json',
         },
         icons: {
           '16': '16.png',

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -258,7 +258,10 @@ describe('app', () => {
   });
 
   it('verifies TTL behavior with read count', async () => {
-    const initialTTL = 5000;
+    // Keep TTL well above CI scheduling jitter — a 5s TTL previously expired before
+    // the GET when this suite ran ~5.2s under load.
+    const initialTTL = 30_000;
+    const waitMs = 1_000;
     const readCount = 3;
     const createResponse = await testContext.client.request({
       method: 'POST',
@@ -291,7 +294,7 @@ describe('app', () => {
 
     // Under CI CPU contention setTimeout can fire much later than requested; assert
     // against wall-clock elapsed instead of assuming the delay was exact.
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, waitMs));
 
     const getResponse = await testContext.client.request({
       method: 'GET',
@@ -304,7 +307,7 @@ describe('app', () => {
     // Reading with remaining read-count must preserve the remaining TTL (not reset it).
     expect(ttlAfterRead).toBeGreaterThan(0);
     expect(ttlAfterRead).toBeLessThan(initialRedisTTL);
-    expect(Math.abs(ttlAfterRead - (initialTTL - elapsedMs))).toBeLessThan(750);
+    expect(Math.abs(ttlAfterRead - (initialTTL - elapsedMs))).toBeLessThan(2_000);
 
     const remainingReads = JSON.parse((await testContext.redis.get(`vault:${id}`)) ?? '{}')?.rc;
     expect(remainingReads).toBe(2);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,7 +186,16 @@ importers:
       webextension-polyfill:
         specifier: ^0.12.0
         version: 0.12.0
+      zod:
+        specifier: ^4.1.5
+        version: 4.4.3
     devDependencies:
+      '@jest/globals':
+        specifier: ^30.4.1
+        version: 30.4.1(supports-color@10.2.2)
+      '@tailwindcss/vite':
+        specifier: 4.3.3
+        version: 4.3.3(vite@8.0.16(@types/node@22.20.1)(esbuild@0.25.0)(jiti@2.7.0)(yaml@2.9.0))
       '@types/chrome':
         specifier: ^0.1.4
         version: 0.1.43
@@ -211,6 +220,12 @@ importers:
       jest:
         specifier: ^30.1.1
         version: 30.4.2(@types/node@22.20.1)(node-notifier@10.0.1)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.9.2))
+      tailwindcss:
+        specifier: ^4.3.3
+        version: 4.3.3
+      ts-jest:
+        specifier: ^29.4.1
+        version: 29.4.12(@babel/core@7.29.6(supports-color@10.2.2))(@jest/transform@30.4.1(supports-color@10.2.2))(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.6(supports-color@10.2.2))(supports-color@10.2.2))(esbuild@0.25.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@22.20.1)(node-notifier@10.0.1)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.9.2)))(typescript@5.9.2)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -3092,6 +3107,11 @@ packages:
 
   '@tailwindcss/postcss@4.3.3':
     resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
+
+  '@tailwindcss/vite@4.3.3':
+    resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
+    peerDependencies:
+      vite: 8.0.16
 
   '@tanstack/history@1.162.0':
     resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
@@ -10096,6 +10116,13 @@ snapshots:
       '@tailwindcss/oxide': 4.3.3
       postcss: 8.5.23
       tailwindcss: 4.3.3
+
+  '@tailwindcss/vite@4.3.3(vite@8.0.16(@types/node@22.20.1)(esbuild@0.25.0)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      tailwindcss: 4.3.3
+      vite: 8.0.16(@types/node@22.20.1)(esbuild@0.25.0)(jiti@2.7.0)(yaml@2.9.0)
 
   '@tanstack/history@1.162.0': {}
 


### PR DESCRIPTION
## Summary
- Add a runtime options page for extension create defaults (endpoints, TTL, burn, IP allow-list, read/failure counts, webhooks; password omitted)
- Seed defaults via `storage.managed` for Chrome/Firefox enterprise admins, with user overrides winning over managed over build-time env
- Include managed schema, example policies, import/export JSON, and docs

## Test plan
- [ ] `pnpm --filter @crypt.fyi/extension build` and load `packages/extension/dist` unpacked
- [ ] Open Options from the toolbar icon; confirm TTL dropdown has values and Save/Reset/Import/Export work
- [ ] Context-menu encrypt uses saved defaults (e.g. custom TTL / burn off)
- [ ] Reset restores built-in defaults
- [ ] (Optional) Apply example Chrome/Firefox managed policy and confirm seeded values appear until overridden